### PR TITLE
Feat: 어드민 서비스 로직 및 긴급 공지와 공지 검색

### DIFF
--- a/src/main/java/com/ds/dsfest/DsfestApplication.java
+++ b/src/main/java/com/ds/dsfest/DsfestApplication.java
@@ -1,5 +1,7 @@
 package com.ds.dsfest;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -9,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 public class DsfestApplication {
 
   public static void main(String[] args) {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     SpringApplication.run(DsfestApplication.class, args);
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/admin/AdminProperties.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/AdminProperties.java
@@ -1,0 +1,15 @@
+package com.ds.dsfest.domain.admin;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "admin")
+public class AdminProperties {
+
+  private String username;
+  private String password;
+}

--- a/src/main/java/com/ds/dsfest/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.ds.dsfest.domain.admin.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ds.dsfest.domain.admin.dto.AdminLoginReqDto;
+import com.ds.dsfest.domain.admin.dto.AdminLoginResDto;
+import com.ds.dsfest.domain.admin.service.AdminService;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController implements AdminControllerDocs {
+
+  private final AdminService adminService;
+
+  @PostMapping("/login")
+  public ResponseEntity<ApiResponse<AdminLoginResDto>> login(
+      @RequestBody @Valid AdminLoginReqDto req) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(adminService.login(req)));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/admin/controller/AdminControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/controller/AdminControllerDocs.java
@@ -1,0 +1,17 @@
+package com.ds.dsfest.domain.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.ds.dsfest.domain.admin.dto.AdminLoginReqDto;
+import com.ds.dsfest.domain.admin.dto.AdminLoginResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Admin Auth", description = "어드민 인증 API")
+public interface AdminControllerDocs {
+
+  @Operation(summary = "어드민 로그인", description = "아이디/비밀번호 검증 후 JWT를 발급합니다.")
+  ResponseEntity<ApiResponse<AdminLoginResDto>> login(AdminLoginReqDto req);
+}

--- a/src/main/java/com/ds/dsfest/domain/admin/dto/AdminLoginReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/dto/AdminLoginReqDto.java
@@ -1,0 +1,5 @@
+package com.ds.dsfest.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginReqDto(@NotBlank String username, @NotBlank String password) {}

--- a/src/main/java/com/ds/dsfest/domain/admin/dto/AdminLoginResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/dto/AdminLoginResDto.java
@@ -1,0 +1,3 @@
+package com.ds.dsfest.domain.admin.dto;
+
+public record AdminLoginResDto(String accessToken) {}

--- a/src/main/java/com/ds/dsfest/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/service/AdminService.java
@@ -1,5 +1,7 @@
 package com.ds.dsfest.domain.admin.service;
 
+import java.util.Objects;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +25,7 @@ public class AdminService {
   private final JwtProvider jwtProvider;
 
   public AdminLoginResDto login(AdminLoginReqDto req) {
-    if (!adminProperties.getUsername().equals(req.username())
+    if (!Objects.equals(adminProperties.getUsername(), req.username())
         || !passwordEncoder.matches(req.password(), adminProperties.getPassword())) {
       throw new CustomException(AdminErrorCode.ADMIN_LOGIN_FAILED);
     }

--- a/src/main/java/com/ds/dsfest/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ds/dsfest/domain/admin/service/AdminService.java
@@ -1,0 +1,32 @@
+package com.ds.dsfest.domain.admin.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ds.dsfest.domain.admin.AdminProperties;
+import com.ds.dsfest.domain.admin.dto.AdminLoginReqDto;
+import com.ds.dsfest.domain.admin.dto.AdminLoginResDto;
+import com.ds.dsfest.domain.admin.exception.AdminErrorCode;
+import com.ds.dsfest.global.exception.CustomException;
+import com.ds.dsfest.global.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+  private final AdminProperties adminProperties;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtProvider jwtProvider;
+
+  public AdminLoginResDto login(AdminLoginReqDto req) {
+    if (!adminProperties.getUsername().equals(req.username())
+        || !passwordEncoder.matches(req.password(), adminProperties.getPassword())) {
+      throw new CustomException(AdminErrorCode.ADMIN_LOGIN_FAILED);
+    }
+    return new AdminLoginResDto(jwtProvider.generateToken(req.username()));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/constant/NoticeCategory.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/constant/NoticeCategory.java
@@ -1,8 +1,15 @@
 package com.ds.dsfest.domain.notice.constant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공지 카테고리")
 public enum NoticeCategory {
+  @Schema(description = "이벤트")
   EVENT,
+  @Schema(description = "공연")
   PERFORMANCE,
+  @Schema(description = "기타")
   ETC,
-  RULE
+  @Schema(description = "안내")
+  NOTICE
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
@@ -1,0 +1,76 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.domain.notice.service.NoticeService;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/notices")
+public class AdminNoticeController implements AdminNoticeControllerDocs {
+
+  private final NoticeService noticeService;
+
+  @PostMapping(consumes = "multipart/form-data")
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> createNotice(
+      @RequestPart("data") @Valid NoticeCreateReqDto req,
+      @RequestPart(value = "images", required = false) List<MultipartFile> images)
+      throws IOException {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.createNotice(req, images)));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList() {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeList()));
+  }
+
+  @GetMapping("/{noticeId}")
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(
+      @PathVariable Long noticeId) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetail(noticeId)));
+  }
+
+  @PutMapping(value = "/{noticeId}", consumes = "multipart/form-data")
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> updateNotice(
+      @PathVariable Long noticeId,
+      @RequestPart("data") @Valid NoticeUpdateReqDto req,
+      @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages)
+      throws IOException {
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(noticeService.updateNotice(noticeId, req, newImages)));
+  }
+
+  @DeleteMapping("/{noticeId}")
+  public ResponseEntity<ApiResponse<Void>> deleteNotice(@PathVariable Long noticeId) {
+    noticeService.deleteNotice(noticeId);
+    return ResponseEntity.ok(ApiResponse.onSuccess());
+  }
+
+  @PatchMapping("/urgent/clear")
+  public ResponseEntity<ApiResponse<Void>> clearAllUrgent() {
+    noticeService.clearAllUrgent();
+    return ResponseEntity.ok(ApiResponse.onSuccess());
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerDocs.java
@@ -1,0 +1,72 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Admin Notice", description = "어드민 공지사항 관리 API")
+@SecurityRequirement(name = "BearerAuth")
+public interface AdminNoticeControllerDocs {
+
+  @Operation(
+      summary = "공지 작성",
+      description =
+          "새 공지사항을 작성합니다. 이미지는 선택 사항입니다.\n\n"
+              + "**category** 가능한 값\n"
+              + "- `EVENT` : 이벤트\n"
+              + "- `PERFORMANCE` : 공연\n"
+              + "- `ETC` : 기타\n"
+              + "- `NOTICE` : 안내")
+  @RequestBody(
+      content =
+          @Content(
+              mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+              encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> createNotice(
+      NoticeCreateReqDto req, List<MultipartFile> images) throws IOException;
+
+  @Operation(summary = "공지 리스트 조회", description = "전체 공지사항을 최신순으로 반환합니다.")
+  ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList();
+
+  @Operation(summary = "공지 상세 조회", description = "공지사항 상세 내용을 반환합니다.")
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(Long noticeId);
+
+  @Operation(
+      summary = "공지 수정",
+      description =
+          "공지사항을 수정합니다. keepImageUrls에 유지할 기존 이미지 URL을 순서대로 담아 전송하세요. 포함되지 않은 기존 이미지는 S3에서 삭제됩니다.\n\n"
+              + "**category** 가능한 값\n"
+              + "- `EVENT` : 이벤트\n"
+              + "- `PERFORMANCE` : 공연\n"
+              + "- `ETC` : 기타\n"
+              + "- `NOTICE` : 안내")
+  @RequestBody(
+      content =
+          @Content(
+              mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+              encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> updateNotice(
+      Long noticeId, NoticeUpdateReqDto req, List<MultipartFile> newImages) throws IOException;
+
+  @Operation(summary = "공지 삭제", description = "공지사항과 연관된 S3 이미지를 함께 삭제합니다.")
+  ResponseEntity<ApiResponse<Void>> deleteNotice(Long noticeId);
+
+  @Operation(summary = "전체 긴급공지 해제", description = "모든 공지의 긴급 플래그를 해제합니다.")
+  ResponseEntity<ApiResponse<Void>> clearAllUrgent();
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -1,10 +1,13 @@
 package com.ds.dsfest.domain.notice.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.constraints.NotBlank;
 
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -13,6 +16,7 @@ import com.ds.dsfest.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notices")
@@ -27,7 +31,7 @@ public class NoticeController implements NoticeControllerDocs {
 
   @GetMapping("/search")
   public ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
-      @RequestParam String keyword) {
+      @RequestParam @NotBlank String keyword) {
     return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.searchNotices(keyword)));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -1,0 +1,33 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
+import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
+import com.ds.dsfest.domain.notice.service.NoticeService;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController implements NoticeControllerDocs {
+
+  private final NoticeService noticeService;
+
+  @GetMapping("/urgent")
+  public ResponseEntity<ApiResponse<UrgentNoticeResDto>> getUrgentNotice() {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getUrgentNotice()));
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
+      @RequestParam String keyword) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.searchNotices(keyword)));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -1,0 +1,24 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
+import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Notice", description = "공지사항 사용자 API")
+public interface NoticeControllerDocs {
+
+  @Operation(
+      summary = "긴급공지 조회",
+      description = "긴급 플래그가 설정된 공지 중 가장 최신 1건의 id와 제목을 반환합니다. 긴급공지가 없으면 result가 null입니다.")
+  ResponseEntity<ApiResponse<UrgentNoticeResDto>> getUrgentNotice();
+
+  @Operation(
+      summary = "공지 검색",
+      description = "keyword로 제목·본문을 검색합니다. 결과가 없으면 results는 빈 배열, recommended에 조회수 상위 3개가 담깁니다.")
+  ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(String keyword);
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeCreateReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeCreateReqDto.java
@@ -1,0 +1,12 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+
+public record NoticeCreateReqDto(
+    @NotBlank String title,
+    @NotNull NoticeCategory category,
+    boolean urgent,
+    @NotBlank String content) {}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeCreateReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeCreateReqDto.java
@@ -2,11 +2,12 @@ package com.ds.dsfest.domain.notice.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 
 public record NoticeCreateReqDto(
-    @NotBlank String title,
+    @NotBlank @Size(max = 255) String title,
     @NotNull NoticeCategory category,
     boolean urgent,
     @NotBlank String content) {}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeDetailResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeDetailResDto.java
@@ -1,0 +1,31 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.entity.Notice;
+
+public record NoticeDetailResDto(
+    Long id,
+    String title,
+    NoticeCategory category,
+    boolean urgent,
+    String content,
+    List<String> imageUrls,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  public static NoticeDetailResDto from(Notice notice) {
+    List<String> imageUrls = notice.getImages().stream().map(image -> image.getImageUrl()).toList();
+    return new NoticeDetailResDto(
+        notice.getId(),
+        notice.getTitle(),
+        notice.getCategory(),
+        notice.isUrgent(),
+        notice.getContent(),
+        imageUrls,
+        notice.getCreatedAt(),
+        notice.getUpdatedAt());
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeListItemResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeListItemResDto.java
@@ -1,0 +1,19 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import java.time.LocalDateTime;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.entity.Notice;
+
+public record NoticeListItemResDto(
+    Long id, String title, NoticeCategory category, boolean urgent, LocalDateTime createdAt) {
+
+  public static NoticeListItemResDto from(Notice notice) {
+    return new NoticeListItemResDto(
+        notice.getId(),
+        notice.getTitle(),
+        notice.getCategory(),
+        notice.isUrgent(),
+        notice.getCreatedAt());
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeSearchResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeSearchResDto.java
@@ -1,0 +1,6 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import java.util.List;
+
+public record NoticeSearchResDto(
+    List<NoticeListItemResDto> results, List<NoticeListItemResDto> recommended) {}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeUpdateReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeUpdateReqDto.java
@@ -1,0 +1,15 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+
+public record NoticeUpdateReqDto(
+    @NotBlank String title,
+    @NotNull NoticeCategory category,
+    boolean urgent,
+    @NotBlank String content,
+    List<String> keepImageUrls) {}

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/UrgentNoticeResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/UrgentNoticeResDto.java
@@ -1,0 +1,10 @@
+package com.ds.dsfest.domain.notice.dto;
+
+import com.ds.dsfest.domain.notice.entity.Notice;
+
+public record UrgentNoticeResDto(Long id, String title) {
+
+  public static UrgentNoticeResDto from(Notice notice) {
+    return new UrgentNoticeResDto(notice.getId(), notice.getTitle());
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/entity/Notice.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/entity/Notice.java
@@ -51,4 +51,33 @@ public class Notice extends BaseEntity {
   @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderBy("imageOrder ASC")
   private List<NoticeImage> images = new ArrayList<>();
+
+  public static Notice create(
+      String title, String content, NoticeCategory category, boolean urgent) {
+    Notice notice = new Notice();
+    notice.title = title;
+    notice.content = content;
+    notice.category = category;
+    notice.urgent = urgent;
+    return notice;
+  }
+
+  public void update(String title, String content, NoticeCategory category, boolean urgent) {
+    this.title = title;
+    this.content = content;
+    this.category = category;
+    this.urgent = urgent;
+  }
+
+  public void clearUrgent() {
+    this.urgent = false;
+  }
+
+  public void addImage(String imageUrl, int order) {
+    this.images.add(NoticeImage.create(this, imageUrl, order));
+  }
+
+  public void clearImages() {
+    this.images.clear();
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/entity/NoticeImage.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/entity/NoticeImage.java
@@ -33,4 +33,12 @@ public class NoticeImage {
 
   @Column(nullable = false)
   private int imageOrder;
+
+  public static NoticeImage create(Notice notice, String imageUrl, int imageOrder) {
+    NoticeImage image = new NoticeImage();
+    image.notice = notice;
+    image.imageUrl = imageUrl;
+    image.imageOrder = imageOrder;
+    return image;
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/exception/NoticeErrorCode.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/exception/NoticeErrorCode.java
@@ -1,0 +1,18 @@
+package com.ds.dsfest.domain.notice.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.ds.dsfest.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeErrorCode implements BaseErrorCode {
+  NOTICE_NOT_FOUND("NOTICE001", "공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,32 @@
+package com.ds.dsfest.domain.notice.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ds.dsfest.domain.notice.entity.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+  List<Notice> findAllByOrderByCreatedAtDesc();
+
+  Optional<Notice> findTopByUrgentTrueOrderByCreatedAtDesc();
+
+  @Query(
+      "SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdAt DESC")
+  List<Notice> searchByKeyword(@Param("keyword") String keyword);
+
+  List<Notice> findTop3ByOrderByViewCountDesc();
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")
+  void incrementViewCount(@Param("id") Long id);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE Notice n SET n.urgent = false WHERE n.urgent = true")
+  void clearAllUrgent();
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -1,0 +1,148 @@
+package com.ds.dsfest.domain.notice.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
+import com.ds.dsfest.domain.notice.entity.Notice;
+import com.ds.dsfest.domain.notice.exception.NoticeErrorCode;
+import com.ds.dsfest.domain.notice.repository.NoticeRepository;
+import com.ds.dsfest.global.exception.CustomException;
+import com.ds.dsfest.global.infra.s3.S3Uploader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticeService {
+
+  private static final String S3_DIR = "notices";
+
+  private final NoticeRepository noticeRepository;
+  private final S3Uploader s3Uploader;
+
+  public NoticeDetailResDto createNotice(NoticeCreateReqDto req, List<MultipartFile> images)
+      throws IOException {
+    Notice notice = Notice.create(req.title(), req.content(), req.category(), req.urgent());
+    noticeRepository.save(notice);
+
+    if (images != null) {
+      uploadAndAttachImages(notice, images, 0);
+    }
+
+    return NoticeDetailResDto.from(notice);
+  }
+
+  @Transactional(readOnly = true)
+  public List<NoticeListItemResDto> getNoticeList() {
+    return noticeRepository.findAllByOrderByCreatedAtDesc().stream()
+        .map(NoticeListItemResDto::from)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public NoticeDetailResDto getNoticeDetail(Long noticeId) {
+    Notice notice = findNoticeOrThrow(noticeId);
+    return NoticeDetailResDto.from(notice);
+  }
+
+  public NoticeDetailResDto getNoticeDetailWithViewCount(Long noticeId) {
+    noticeRepository.incrementViewCount(noticeId);
+    Notice notice = findNoticeOrThrow(noticeId);
+    return NoticeDetailResDto.from(notice);
+  }
+
+  public NoticeDetailResDto updateNotice(
+      Long noticeId, NoticeUpdateReqDto req, List<MultipartFile> newImages) throws IOException {
+    Notice notice = findNoticeOrThrow(noticeId);
+    notice.update(req.title(), req.content(), req.category(), req.urgent());
+
+    List<String> keepUrls = req.keepImageUrls() != null ? req.keepImageUrls() : List.of();
+    replaceImages(notice, keepUrls, newImages);
+
+    noticeRepository.flush();
+    return NoticeDetailResDto.from(notice);
+  }
+
+  public void deleteNotice(Long noticeId) {
+    Notice notice = findNoticeOrThrow(noticeId);
+    notice.getImages().forEach(image -> s3Uploader.delete(image.getImageUrl()));
+    noticeRepository.delete(notice);
+  }
+
+  public void clearAllUrgent() {
+    noticeRepository.clearAllUrgent();
+  }
+
+  @Transactional(readOnly = true)
+  public NoticeSearchResDto searchNotices(String keyword) {
+    List<NoticeListItemResDto> results =
+        noticeRepository.searchByKeyword(keyword).stream().map(NoticeListItemResDto::from).toList();
+
+    List<NoticeListItemResDto> recommended =
+        results.isEmpty()
+            ? noticeRepository.findTop3ByOrderByViewCountDesc().stream()
+                .map(NoticeListItemResDto::from)
+                .toList()
+            : List.of();
+
+    return new NoticeSearchResDto(results, recommended);
+  }
+
+  @Transactional(readOnly = true)
+  public UrgentNoticeResDto getUrgentNotice() {
+    return noticeRepository
+        .findTopByUrgentTrueOrderByCreatedAtDesc()
+        .map(UrgentNoticeResDto::from)
+        .orElse(null);
+  }
+
+  private void replaceImages(Notice notice, List<String> keepUrls, List<MultipartFile> newImages)
+      throws IOException {
+    List<String> urlsToDelete =
+        notice.getImages().stream()
+            .map(image -> image.getImageUrl())
+            .filter(url -> !keepUrls.contains(url))
+            .toList();
+
+    notice.clearImages();
+
+    List<String> allUrls = new ArrayList<>(keepUrls);
+    if (newImages != null) {
+      for (MultipartFile file : newImages) {
+        allUrls.add(s3Uploader.upload(file, S3_DIR));
+      }
+    }
+
+    for (int i = 0; i < allUrls.size(); i++) {
+      notice.addImage(allUrls.get(i), i);
+    }
+
+    urlsToDelete.forEach(s3Uploader::delete);
+  }
+
+  private void uploadAndAttachImages(Notice notice, List<MultipartFile> images, int startOrder)
+      throws IOException {
+    for (int i = 0; i < images.size(); i++) {
+      String url = s3Uploader.upload(images.get(i), S3_DIR);
+      notice.addImage(url, startOrder + i);
+    }
+  }
+
+  private Notice findNoticeOrThrow(Long noticeId) {
+    return noticeRepository
+        .findById(noticeId)
+        .orElseThrow(() -> new CustomException(NoticeErrorCode.NOTICE_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -3,6 +3,8 @@ package com.ds.dsfest.domain.notice.service;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -110,15 +112,20 @@ public class NoticeService {
 
   private void replaceImages(Notice notice, List<String> keepUrls, List<MultipartFile> newImages)
       throws IOException {
-    List<String> urlsToDelete =
+    Set<String> existingUrls =
         notice.getImages().stream()
             .map(image -> image.getImageUrl())
-            .filter(url -> !keepUrls.contains(url))
-            .toList();
+            .collect(Collectors.toSet());
+
+    List<String> validatedKeepUrls =
+        keepUrls.stream().filter(existingUrls::contains).toList();
+
+    List<String> urlsToDelete =
+        existingUrls.stream().filter(url -> !validatedKeepUrls.contains(url)).toList();
 
     notice.clearImages();
 
-    List<String> allUrls = new ArrayList<>(keepUrls);
+    List<String> allUrls = new ArrayList<>(validatedKeepUrls);
     if (newImages != null) {
       for (MultipartFile file : newImages) {
         allUrls.add(s3Uploader.upload(file, S3_DIR));

--- a/src/main/java/com/ds/dsfest/domain/user/controller/GuestUserControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/user/controller/GuestUserControllerDocs.java
@@ -16,16 +16,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Guest User", description = "게스트 사용자 API")
 public interface GuestUserControllerDocs {
 
-  @Operation(summary = "게스트 사용자 생성", description = "앱 최초 진입 시 UUID를 발급합니다. 이 UUID를 저장하여 이후 요청에 사용합니다.")
+  @Operation(
+      summary = "게스트 사용자 생성",
+      description = "앱 최초 진입 시 UUID를 발급합니다. 이 UUID를 저장하여 이후 요청에 사용합니다.")
   @ApiResponses({
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "UUID 발급 성공"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "UUID 발급 성공"),
   })
   ResponseEntity<ApiResponse<GuestUserResDto>> createGuestUser();
 
   @Operation(summary = "게스트 사용자 조회", description = "저장된 UUID의 유효성을 검증합니다.")
   @ApiResponses({
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 게스트 사용자 (USER_001)"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "조회 성공"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 게스트 사용자 (USER_001)"),
   })
   ResponseEntity<ApiResponse<GuestUserResDto>> getGuestUser(
       @Parameter(description = "게스트 UUID") @PathVariable UUID uuid);

--- a/src/main/java/com/ds/dsfest/global/config/SecurityConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/SecurityConfig.java
@@ -15,9 +15,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import com.ds.dsfest.global.exception.GlobalErrorCode;
+import com.ds.dsfest.global.jwt.JwtAuthenticationFilter;
 import com.ds.dsfest.global.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,6 +32,7 @@ public class SecurityConfig {
 
   private final CorsConfigurationSource corsConfigurationSource;
   private final ObjectMapper objectMapper;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -57,8 +60,7 @@ public class SecurityConfig {
                     // 사용자 공개 엔드포인트
                     .anyRequest()
                     .permitAll())
-        // TODO: 어드민 JWT 필터 구현 후 아래 주석 해제 예정
-        // .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(
             exception ->
                 exception

--- a/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.ds.dsfest.global.exception;
 
 import java.util.stream.Collectors;
 
+import jakarta.validation.ConstraintViolationException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -37,6 +39,19 @@ public class GlobalExceptionHandler {
             .map(FieldError::getDefaultMessage)
             .collect(Collectors.joining(", "));
     log.warn("ValidationException: {}", errorMessage);
+    return ResponseEntity.status(GlobalErrorCode.INVALID_INPUT.getStatus())
+        .body(ApiResponse.onFailure(GlobalErrorCode.INVALID_INPUT, errorMessage));
+  }
+
+  /** @Validated 파라미터 검증 실패 */
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiResponse<String>> handleConstraintViolationException(
+      ConstraintViolationException e) {
+    String errorMessage =
+        e.getConstraintViolations().stream()
+            .map(v -> v.getMessage())
+            .collect(Collectors.joining(", "));
+    log.warn("ConstraintViolationException: {}", errorMessage);
     return ResponseEntity.status(GlobalErrorCode.INVALID_INPUT.getStatus())
         .body(ApiResponse.onFailure(GlobalErrorCode.INVALID_INPUT, errorMessage));
   }

--- a/src/main/java/com/ds/dsfest/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/ds/dsfest/global/infra/s3/S3Uploader.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class S3Uploader {
@@ -50,6 +52,7 @@ public class S3Uploader {
    */
   public void delete(String fileUrl) {
     if (fileUrl == null || !fileUrl.contains(".amazonaws.com/")) {
+      log.warn("S3 삭제 건너뜀 - 유효하지 않은 URL: {}", fileUrl);
       return;
     }
     String key = extractKey(fileUrl);

--- a/src/main/java/com/ds/dsfest/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/ds/dsfest/global/infra/s3/S3Uploader.java
@@ -49,6 +49,9 @@ public class S3Uploader {
    * @param fileUrl 삭제할 파일의 S3 URL
    */
   public void delete(String fileUrl) {
+    if (fileUrl == null || !fileUrl.contains(".amazonaws.com/")) {
+      return;
+    }
     String key = extractKey(fileUrl);
 
     s3Client.deleteObject(

--- a/src/main/java/com/ds/dsfest/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ds/dsfest/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,76 @@
+package com.ds.dsfest.global.jwt;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ds.dsfest.global.exception.CustomException;
+import com.ds.dsfest.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final JwtProvider jwtProvider;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String token = resolveToken(request);
+    if (token != null) {
+      try {
+        jwtProvider.validate(token);
+        String subject = jwtProvider.extractSubject(token);
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                subject, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      } catch (CustomException e) {
+        writeErrorResponse(response, e);
+        return;
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveToken(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+      return header.substring(BEARER_PREFIX.length());
+    }
+    return null;
+  }
+
+  private void writeErrorResponse(HttpServletResponse response, CustomException e)
+      throws IOException {
+    response.setStatus(e.getErrorCode().getStatus().value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response
+        .getWriter()
+        .write(objectMapper.writeValueAsString(ApiResponse.onFailure(e.getErrorCode())));
+  }
+}

--- a/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
+++ b/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.ds.dsfest.global.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+  private String secret;
+}

--- a/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
+++ b/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
@@ -1,14 +1,18 @@
 package com.ds.dsfest.global.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Validated
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
+  @NotBlank
   private String secret;
 }

--- a/src/main/java/com/ds/dsfest/global/jwt/JwtProvider.java
+++ b/src/main/java/com/ds/dsfest/global/jwt/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.ds.dsfest.global.jwt;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.ds.dsfest.domain.admin.exception.AdminErrorCode;
+import com.ds.dsfest.global.exception.CustomException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+  private static final long EXPIRATION_MS = 24 * 60 * 60 * 1000L;
+
+  private final JwtProperties jwtProperties;
+
+  public String generateToken(String subject) {
+    Date now = new Date();
+    return Jwts.builder()
+        .subject(subject)
+        .issuedAt(now)
+        .expiration(new Date(now.getTime() + EXPIRATION_MS))
+        .signWith(secretKey())
+        .compact();
+  }
+
+  public String extractSubject(String token) {
+    return parseClaims(token).getSubject();
+  }
+
+  public void validate(String token) {
+    parseClaims(token);
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().verifyWith(secretKey()).build().parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(AdminErrorCode.ADMIN_TOKEN_EXPIRED);
+    } catch (JwtException | IllegalArgumentException e) {
+      throw new CustomException(AdminErrorCode.ADMIN_TOKEN_INVALID);
+    }
+  }
+
+  private SecretKey secretKey() {
+    return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getSecret()));
+  }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,13 +17,11 @@ spring:
       enabled: false
 
 jwt:
-  secret: test-secret-key-that-is-at-least-256-bits-long-for-hs256-algorithm-padding
-  access-expiration: 3600000
-  refresh-expiration: 604800000
+  secret: dGVzdFNlY3JldEtleUZvclRlc3RpbmdEU0Zlc3QyMDI2UHVycG9zZXNPbmx5QUE=
 
 admin:
   username: test-admin
-  password: $2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+  password: $2a$10$Snc5cpoPC3iFCUL1xtg6Z.7UqNkV23kc2hrf.GUZz7YFJPuDaPg.a
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,9 @@ spring:
   application:
     name: dsfest
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local}
+    active: ${SPRING_PROFILES_ACTIVE}
+  jackson:
+    time-zone: Asia/Seoul
 
 server:
   port: 8080

--- a/src/test/java/com/ds/dsfest/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/ds/dsfest/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,96 @@
+package com.ds.dsfest.domain.admin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AdminControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @Test
+  @DisplayName("올바른 자격증명으로 로그인하면 accessToken을 반환한다")
+  void login_success() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/admin/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of(
+                            "username", "test-admin",
+                            "password", "test-password"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result.accessToken").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("비밀번호가 틀리면 401을 반환한다")
+  void login_wrongPassword_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/admin/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of(
+                            "username", "test-admin",
+                            "password", "wrong-password"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("ADMIN001"));
+  }
+
+  @Test
+  @DisplayName("아이디가 틀리면 401을 반환한다")
+  void login_wrongUsername_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/admin/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of(
+                            "username", "wrong-admin",
+                            "password", "test-password"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("ADMIN001"));
+  }
+
+  @Test
+  @DisplayName("username이 빈 값이면 400을 반환한다")
+  void login_blankUsername_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/admin/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of(
+                            "username", "",
+                            "password", "test-password"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false));
+  }
+}

--- a/src/test/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerTest.java
@@ -55,7 +55,7 @@ class AdminNoticeControllerTest {
   }
 
   @Test
-  @DisplayName("공지를 이미지 없이 작성하면 201을 반환한다")
+  @DisplayName("공지를 이미지 없이 작성하면 200을 반환한다")
   void createNotice_withoutImages_success() throws Exception {
     NoticeCreateReqDto req =
         new NoticeCreateReqDto("테스트 공지", NoticeCategory.ETC, false, "공지 내용입니다.");
@@ -180,7 +180,7 @@ class AdminNoticeControllerTest {
   }
 
   @Test
-  @DisplayName("공지를 삭제하면 204와 isSuccess true를 반환한다")
+  @DisplayName("공지를 삭제하면 200과 isSuccess true를 반환한다")
   void deleteNotice_success() throws Exception {
     Notice saved = noticeRepository.save(Notice.create("삭제할 공지", "내용", NoticeCategory.ETC, false));
 

--- a/src/test/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/controller/AdminNoticeControllerTest.java
@@ -1,0 +1,209 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.domain.notice.entity.Notice;
+import com.ds.dsfest.domain.notice.repository.NoticeRepository;
+import com.ds.dsfest.global.infra.s3.S3Uploader;
+import com.ds.dsfest.global.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AdminNoticeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private NoticeRepository noticeRepository;
+  @Autowired private JwtProvider jwtProvider;
+  @MockitoBean private S3Uploader s3Uploader;
+
+  private String authHeader;
+
+  @BeforeEach
+  void setUp() {
+    authHeader = "Bearer " + jwtProvider.generateToken("test-admin");
+  }
+
+  @Test
+  @DisplayName("공지를 이미지 없이 작성하면 201을 반환한다")
+  void createNotice_withoutImages_success() throws Exception {
+    NoticeCreateReqDto req =
+        new NoticeCreateReqDto("테스트 공지", NoticeCategory.ETC, false, "공지 내용입니다.");
+
+    MockMultipartFile dataPart =
+        new MockMultipartFile(
+            "data", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(req));
+
+    mockMvc
+        .perform(multipart("/api/admin/notices").file(dataPart).header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result.title").value("테스트 공지"))
+        .andExpect(jsonPath("$.result.category").value("ETC"))
+        .andExpect(jsonPath("$.result.urgent").value(false));
+  }
+
+  @Test
+  @DisplayName("공지를 이미지와 함께 작성하면 S3에 업로드된 URL이 포함된다")
+  void createNotice_withImages_success() throws Exception {
+    when(s3Uploader.upload(any(), eq("notices")))
+        .thenReturn("https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/uuid_test.jpg");
+
+    NoticeCreateReqDto req =
+        new NoticeCreateReqDto("이미지 공지", NoticeCategory.EVENT, true, "긴급 공지입니다.");
+
+    MockMultipartFile dataPart =
+        new MockMultipartFile(
+            "data", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(req));
+    MockMultipartFile imagePart =
+        new MockMultipartFile(
+            "images", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "fake-image".getBytes());
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/notices")
+                .file(dataPart)
+                .file(imagePart)
+                .header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.result.imageUrls[0]")
+                .value("https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/uuid_test.jpg"));
+  }
+
+  @Test
+  @DisplayName("JWT 없이 공지 작성 요청하면 401을 반환한다")
+  void createNotice_withoutAuth_returnsUnauthorized() throws Exception {
+    NoticeCreateReqDto req = new NoticeCreateReqDto("공지", NoticeCategory.ETC, false, "내용");
+    MockMultipartFile dataPart =
+        new MockMultipartFile(
+            "data", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(req));
+
+    mockMvc
+        .perform(multipart("/api/admin/notices").file(dataPart))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("공지 리스트를 최신순으로 조회한다")
+  void getNoticeList_success() throws Exception {
+    noticeRepository.save(Notice.create("공지1", "내용1", NoticeCategory.ETC, false));
+    noticeRepository.save(Notice.create("공지2", "내용2", NoticeCategory.EVENT, true));
+
+    mockMvc
+        .perform(get("/api/admin/notices").header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result").isArray())
+        .andExpect(jsonPath("$.result[0].title").value("공지2"));
+  }
+
+  @Test
+  @DisplayName("공지 상세를 조회한다")
+  void getNoticeDetail_success() throws Exception {
+    Notice saved =
+        noticeRepository.save(Notice.create("상세공지", "상세내용", NoticeCategory.NOTICE, false));
+
+    mockMvc
+        .perform(
+            get("/api/admin/notices/{noticeId}", saved.getId()).header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.id").value(saved.getId()))
+        .andExpect(jsonPath("$.result.title").value("상세공지"))
+        .andExpect(jsonPath("$.result.content").value("상세내용"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공지 조회 시 404를 반환한다")
+  void getNoticeDetail_notFound_returns404() throws Exception {
+    mockMvc
+        .perform(get("/api/admin/notices/{noticeId}", 99999L).header("Authorization", authHeader))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOTICE001"));
+  }
+
+  @Test
+  @DisplayName("공지를 수정하면 변경된 내용이 반환된다")
+  void updateNotice_success() throws Exception {
+    Notice saved =
+        noticeRepository.save(Notice.create("원본 제목", "원본 내용", NoticeCategory.ETC, false));
+
+    NoticeUpdateReqDto req =
+        new NoticeUpdateReqDto("수정된 제목", NoticeCategory.EVENT, true, "수정된 내용", List.of());
+    MockMultipartFile dataPart =
+        new MockMultipartFile(
+            "data", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(req));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/notices/{noticeId}", saved.getId())
+                .file(dataPart)
+                .with(
+                    r -> {
+                      r.setMethod("PUT");
+                      return r;
+                    })
+                .header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.title").value("수정된 제목"))
+        .andExpect(jsonPath("$.result.urgent").value(true));
+  }
+
+  @Test
+  @DisplayName("공지를 삭제하면 204와 isSuccess true를 반환한다")
+  void deleteNotice_success() throws Exception {
+    Notice saved = noticeRepository.save(Notice.create("삭제할 공지", "내용", NoticeCategory.ETC, false));
+
+    mockMvc
+        .perform(
+            delete("/api/admin/notices/{noticeId}", saved.getId())
+                .header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true));
+  }
+
+  @Test
+  @DisplayName("전체 긴급공지 해제 시 모든 공지의 urgent가 false가 된다")
+  void clearAllUrgent_success() throws Exception {
+    noticeRepository.save(Notice.create("긴급1", "내용1", NoticeCategory.ETC, true));
+    noticeRepository.save(Notice.create("긴급2", "내용2", NoticeCategory.ETC, true));
+
+    mockMvc
+        .perform(patch("/api/admin/notices/urgent/clear").header("Authorization", authHeader))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true));
+
+    List<Notice> all = noticeRepository.findAllByOrderByCreatedAtDesc();
+    assertThat(all).noneMatch(Notice::isUrgent);
+  }
+}

--- a/src/test/java/com/ds/dsfest/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,93 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.entity.Notice;
+import com.ds.dsfest.domain.notice.repository.NoticeRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class NoticeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private NoticeRepository noticeRepository;
+
+  @Test
+  @DisplayName("긴급공지가 있으면 최신 1개의 id와 title을 반환한다")
+  void getUrgentNotice_exists_returnsLatest() throws Exception {
+    Notice old = noticeRepository.save(Notice.create("오래된 긴급공지", "내용", NoticeCategory.ETC, true));
+    Notice latest = noticeRepository.save(Notice.create("최신 긴급공지", "내용", NoticeCategory.ETC, true));
+
+    mockMvc
+        .perform(get("/api/notices/urgent"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result.id").value(latest.getId()))
+        .andExpect(jsonPath("$.result.title").value("최신 긴급공지"));
+  }
+
+  @Test
+  @DisplayName("긴급공지가 없으면 result가 null이다")
+  void getUrgentNotice_none_returnsNullResult() throws Exception {
+    noticeRepository.save(Notice.create("일반 공지", "내용", NoticeCategory.ETC, false));
+
+    mockMvc
+        .perform(get("/api/notices/urgent"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("키워드로 공지를 검색하면 제목·본문 일치 결과를 반환한다")
+  void searchNotices_found_returnsResults() throws Exception {
+    noticeRepository.save(
+        Notice.create("무대 입장 안내", "1번 게이트로 입장", NoticeCategory.PERFORMANCE, false));
+    noticeRepository.save(Notice.create("푸드트럭 안내", "B구역에 위치합니다", NoticeCategory.ETC, false));
+
+    mockMvc
+        .perform(get("/api/notices/search").param("keyword", "무대"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.results").isArray())
+        .andExpect(jsonPath("$.result.results[0].title").value("무대 입장 안내"))
+        .andExpect(jsonPath("$.result.recommended").isEmpty());
+  }
+
+  @Test
+  @DisplayName("검색 결과가 없으면 results는 비어있고 조회수 상위 공지가 recommended에 담긴다")
+  void searchNotices_notFound_returnsRecommended() throws Exception {
+    noticeRepository.save(Notice.create("자주 찾는 공지1", "내용1", NoticeCategory.ETC, false));
+    noticeRepository.save(Notice.create("자주 찾는 공지2", "내용2", NoticeCategory.ETC, false));
+
+    mockMvc
+        .perform(get("/api/notices/search").param("keyword", "존재하지않는키워드xyz"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.results").isEmpty())
+        .andExpect(jsonPath("$.result.recommended").isArray());
+  }
+
+  @Test
+  @DisplayName("본문에 키워드가 있어도 검색 결과에 포함된다")
+  void searchNotices_keywordInContent_returnsResult() throws Exception {
+    noticeRepository.save(Notice.create("공지 제목", "본문에 게이트 정보가 있습니다", NoticeCategory.ETC, false));
+
+    mockMvc
+        .perform(get("/api/notices/search").param("keyword", "게이트"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.results[0].title").value("공지 제목"));
+  }
+}

--- a/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
@@ -1,0 +1,208 @@
+package com.ds.dsfest.domain.notice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
+import com.ds.dsfest.domain.notice.entity.Notice;
+import com.ds.dsfest.domain.notice.exception.NoticeErrorCode;
+import com.ds.dsfest.domain.notice.repository.NoticeRepository;
+import com.ds.dsfest.global.exception.CustomException;
+import com.ds.dsfest.global.infra.s3.S3Uploader;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+  @Mock private NoticeRepository noticeRepository;
+  @Mock private S3Uploader s3Uploader;
+  @InjectMocks private NoticeService noticeService;
+
+  @Test
+  @DisplayName("사용자 공지 상세 조회 시 조회수가 1 증가한다")
+  void getNoticeDetailWithViewCount_incrementsViewCount() {
+    Notice notice = Notice.create("제목", "내용", NoticeCategory.ETC, false);
+    when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+    noticeService.getNoticeDetailWithViewCount(1L);
+
+    verify(noticeRepository).incrementViewCount(1L);
+  }
+
+  @Test
+  @DisplayName("어드민 공지 상세 조회 시 조회수가 증가하지 않는다")
+  void getNoticeDetail_doesNotIncrementViewCount() {
+    Notice notice = Notice.create("제목", "내용", NoticeCategory.ETC, false);
+    when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+    noticeService.getNoticeDetail(1L);
+
+    verify(noticeRepository, never()).incrementViewCount(any());
+  }
+
+  @Test
+  @DisplayName("이미지 없이 공지를 생성하면 S3 업로드를 호출하지 않는다")
+  void createNotice_withoutImages_noS3Upload() throws IOException {
+    NoticeCreateReqDto req = new NoticeCreateReqDto("제목", NoticeCategory.ETC, false, "내용");
+    Notice notice = Notice.create("제목", "내용", NoticeCategory.ETC, false);
+    when(noticeRepository.save(any())).thenReturn(notice);
+
+    noticeService.createNotice(req, null);
+
+    verify(s3Uploader, never()).upload(any(), any());
+  }
+
+  @Test
+  @DisplayName("이미지와 함께 공지를 생성하면 S3 업로드가 이미지 수만큼 호출된다")
+  void createNotice_withImages_uploadsToS3() throws IOException {
+    NoticeCreateReqDto req = new NoticeCreateReqDto("제목", NoticeCategory.ETC, false, "내용");
+    Notice notice = Notice.create("제목", "내용", NoticeCategory.ETC, false);
+    when(noticeRepository.save(any())).thenReturn(notice);
+    when(s3Uploader.upload(any(), eq("notices")))
+        .thenReturn("https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/uuid_1.jpg")
+        .thenReturn("https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/uuid_2.jpg");
+
+    List<MultipartFile> images =
+        List.of(
+            new MockMultipartFile("img1", "1.jpg", "image/jpeg", "data1".getBytes()),
+            new MockMultipartFile("img2", "2.jpg", "image/jpeg", "data2".getBytes()));
+
+    NoticeDetailResDto result = noticeService.createNotice(req, images);
+
+    verify(s3Uploader, times(2)).upload(any(), eq("notices"));
+    assertThat(result.imageUrls()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("공지 수정 시 keepImageUrls에 없는 기존 이미지는 S3에서 삭제된다")
+  void updateNotice_removesUnkeptImages() throws IOException {
+    String oldUrl = "https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/old.jpg";
+    Notice notice = Notice.create("원본", "내용", NoticeCategory.ETC, false);
+    notice.addImage(oldUrl, 0);
+    when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+    NoticeUpdateReqDto req =
+        new NoticeUpdateReqDto("수정", NoticeCategory.EVENT, false, "수정 내용", List.of());
+
+    noticeService.updateNotice(1L, req, null);
+
+    verify(s3Uploader).delete(oldUrl);
+  }
+
+  @Test
+  @DisplayName("공지 수정 시 keepImageUrls에 포함된 이미지는 S3에서 삭제하지 않는다")
+  void updateNotice_keepsIncludedImages() throws IOException {
+    String keepUrl = "https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/keep.jpg";
+    Notice notice = Notice.create("원본", "내용", NoticeCategory.ETC, false);
+    notice.addImage(keepUrl, 0);
+    when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+    NoticeUpdateReqDto req =
+        new NoticeUpdateReqDto("수정", NoticeCategory.EVENT, false, "수정 내용", List.of(keepUrl));
+
+    noticeService.updateNotice(1L, req, null);
+
+    verify(s3Uploader, never()).delete(keepUrl);
+  }
+
+  @Test
+  @DisplayName("공지를 삭제하면 연결된 모든 이미지가 S3에서 삭제된다")
+  void deleteNotice_deletesAllImagesFromS3() {
+    String url1 = "https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/img1.jpg";
+    String url2 = "https://DSFest.s3.ap-northeast-2.amazonaws.com/notices/img2.jpg";
+    Notice notice = Notice.create("제목", "내용", NoticeCategory.ETC, false);
+    notice.addImage(url1, 0);
+    notice.addImage(url2, 1);
+    when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+    noticeService.deleteNotice(1L);
+
+    verify(s3Uploader).delete(url1);
+    verify(s3Uploader).delete(url2);
+    verify(noticeRepository).delete(notice);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공지 삭제 시 NOTICE_NOT_FOUND 예외가 발생한다")
+  void deleteNotice_notFound_throwsException() {
+    when(noticeRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> noticeService.deleteNotice(999L))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getErrorCode())
+        .isEqualTo(NoticeErrorCode.NOTICE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("검색 결과가 없으면 recommended에 조회수 상위 공지가 담긴다")
+  void searchNotices_empty_returnsRecommended() {
+    Notice recommended = Notice.create("자주 찾는 공지", "내용", NoticeCategory.ETC, false);
+    when(noticeRepository.searchByKeyword("없는키워드")).thenReturn(List.of());
+    when(noticeRepository.findTop3ByOrderByViewCountDesc()).thenReturn(List.of(recommended));
+
+    NoticeSearchResDto result = noticeService.searchNotices("없는키워드");
+
+    assertThat(result.results()).isEmpty();
+    assertThat(result.recommended()).hasSize(1);
+    assertThat(result.recommended().get(0).title()).isEqualTo("자주 찾는 공지");
+  }
+
+  @Test
+  @DisplayName("검색 결과가 있으면 recommended는 빈 리스트다")
+  void searchNotices_found_noRecommended() {
+    Notice found = Notice.create("무대 안내", "내용", NoticeCategory.PERFORMANCE, false);
+    when(noticeRepository.searchByKeyword("무대")).thenReturn(List.of(found));
+
+    NoticeSearchResDto result = noticeService.searchNotices("무대");
+
+    assertThat(result.results()).hasSize(1);
+    assertThat(result.recommended()).isEmpty();
+    verify(noticeRepository, never()).findTop3ByOrderByViewCountDesc();
+  }
+
+  @Test
+  @DisplayName("긴급공지가 없으면 null을 반환한다")
+  void getUrgentNotice_none_returnsNull() {
+    when(noticeRepository.findTopByUrgentTrueOrderByCreatedAtDesc()).thenReturn(Optional.empty());
+
+    UrgentNoticeResDto result = noticeService.getUrgentNotice();
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("긴급공지가 있으면 id와 title을 반환한다")
+  void getUrgentNotice_exists_returnsDto() {
+    Notice urgent = Notice.create("긴급공지 제목", "내용", NoticeCategory.ETC, true);
+    when(noticeRepository.findTopByUrgentTrueOrderByCreatedAtDesc())
+        .thenReturn(Optional.of(urgent));
+
+    UrgentNoticeResDto result = noticeService.getUrgentNotice();
+
+    assertThat(result).isNotNull();
+    assertThat(result.title()).isEqualTo("긴급공지 제목");
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #3
## 📝 작업 내용
- JWT 인증 필터 구현 (HS256, 24h 만료) 및 SecurityConfig 연결
- 환경변수 기반 어드민 단일 계정 로그인 API 구현 (BCrypt 검증 → JWT 발급)
- Notice·NoticeImage 엔티티 팩토리 및 업데이트 메서드 추가
- 어드민 공지사항 CRUD API 구현 (작성·수정·삭제·리스트·상세, S3 이미지 연동)
- 긴급공지 최신 1개 조회 및 전체 긴급공지 일괄 해제 API 구현
- 공지 제목·본문 LIKE 검색 API 구현 (결과 없을 시 조회수 상위 3개 추천)
### 스크린샷 (선택)
## 📌 API 목록
| Method | URL | 설명 | 인증 |
|--------|-----|------|------|
| POST | /api/admin/login | 어드민 로그인 (JWT 발급) | - |
| GET | /api/admin/notices | 공지 리스트 조회 | JWT |
| POST | /api/admin/notices | 공지 작성 (S3 이미지 포함) | JWT |
| GET | /api/admin/notices/{id} | 공지 상세 조회 | JWT |
| PUT | /api/admin/notices/{id} | 공지 수정 | JWT |
| DELETE | /api/admin/notices/{id} | 공지 삭제 | JWT |
| PATCH | /api/admin/notices/urgent/clear | 전체 긴급공지 해제 | JWT |
| GET | /api/notices/urgent | 긴급공지 최신 1개 조회 | - |
| GET | /api/notices/search | 공지 검색 (keyword) | - |
## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- 어드민 계정은 DB 테이블 없이 환경변수(`ADMIN_USERNAME`, `ADMIN_PASSWORD`)로만 관리
- 공지 수정 시 `keepImageUrls` 목록 기준으로 제외된 이미지는 S3에서 자동 삭제
- 검색 결과 없을 시 조회수(`viewCount`) 상위 3개 추천 공지 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자 로그인(JWT) 및 인증 적용
  * 공지사항 CRUD, 이미지 업로드, 검색·추천, 긴급 공지 조회 제공

* **Bug Fixes**
  * 잘못된 S3 URL 삭제 방지로 파일 삭제 안정성 개선
  * 요청 유효성 검사 오류 응답 메시지 개선

* **Chores**
  * 애플리케이션 기본 타임존을 Asia/Seoul로 설정
  * 요청 처리 파이프라인에 JWT 인증 필터 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->