### PR TITLE
Chore: Spotless 빌드 시 자동 적용 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ spotless {
 	}
 }
 
+tasks.named('compileJava') {
+	dependsOn 'spotlessApply'
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.constraints.NotBlank;
-
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
 import com.ds.dsfest.domain.notice.service.NoticeService;
@@ -31,7 +29,7 @@ public class NoticeController implements NoticeControllerDocs {
 
   @GetMapping("/search")
   public ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
-      @RequestParam @NotBlank String keyword) {
+      @RequestParam String keyword) {
     return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.searchNotices(keyword)));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -1,6 +1,9 @@
 package com.ds.dsfest.domain.notice.controller;
 
+import jakarta.validation.constraints.NotBlank;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -20,5 +23,6 @@ public interface NoticeControllerDocs {
   @Operation(
       summary = "공지 검색",
       description = "keyword로 제목·본문을 검색합니다. 결과가 없으면 results는 빈 배열, recommended에 조회수 상위 3개가 담깁니다.")
-  ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(String keyword);
+  ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
+      @RequestParam @NotBlank String keyword);
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -113,12 +113,9 @@ public class NoticeService {
   private void replaceImages(Notice notice, List<String> keepUrls, List<MultipartFile> newImages)
       throws IOException {
     Set<String> existingUrls =
-        notice.getImages().stream()
-            .map(image -> image.getImageUrl())
-            .collect(Collectors.toSet());
+        notice.getImages().stream().map(image -> image.getImageUrl()).collect(Collectors.toSet());
 
-    List<String> validatedKeepUrls =
-        keepUrls.stream().filter(existingUrls::contains).toList();
+    List<String> validatedKeepUrls = keepUrls.stream().filter(existingUrls::contains).toList();
 
     List<String> urlsToDelete =
         existingUrls.stream().filter(url -> !validatedKeepUrls.contains(url)).toList();

--- a/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
@@ -43,7 +43,9 @@ public class GlobalExceptionHandler {
         .body(ApiResponse.onFailure(GlobalErrorCode.INVALID_INPUT, errorMessage));
   }
 
-  /** @Validated 파라미터 검증 실패 */
+  /**
+   * @Validated 파라미터 검증 실패
+   */
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<ApiResponse<String>> handleConstraintViolationException(
       ConstraintViolationException e) {

--- a/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
+++ b/src/main/java/com/ds/dsfest/global/jwt/JwtProperties.java
@@ -1,9 +1,10 @@
 package com.ds.dsfest.global.jwt;
 
+import jakarta.validation.constraints.NotBlank;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,6 +14,5 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-  @NotBlank
-  private String secret;
+  @NotBlank private String secret;
 }


### PR DESCRIPTION
  - compileJava 태스크에 spotlessApply 의존성 추가

## #️⃣ 연관된 이슈
- 없음

## 📝 작업 내용
- `compileJava` 태스크에 `spotlessApply` 의존성 추가
- 빌드 시 코드 포맷팅이 자동 적용되어 Spotless 검사 실패 방지
## 📌 API 목록
없음
## 💬 리뷰 요구사항 혹은 참고 사항
- 별도 `./gradlew spotlessApply` 실행 없이 빌드 시 자동 포맷 적용됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 공지사항 검색 기능에서 키워드 입력 검증 조건을 조정하여 검색 동작을 개선했습니다.

* **코드 정리**
  * 빌드 프로세스 최적화 및 코드 포맷팅 자동화를 개선했습니다.
  * 내부 코드 구조를 정리하고 문서화를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->