### PR TITLE
Feat: 낮/밤별 부스 목록 조회 api

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
@@ -33,6 +33,12 @@ public class BoothController implements BoothControllerDocs {
     return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getBoothsByDay(day)));
   }
 
+  @GetMapping("/by-time")
+  public ResponseEntity<ApiResponse<List<BoothListItemResDto>>> getBoothsByDayAndType(
+      @RequestParam @Min(1) int day, @RequestParam BoothType type) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getBoothsByDayAndType(day, type)));
+  }
+
   @GetMapping("/map")
   public ResponseEntity<ApiResponse<List<BoothMapItemResDto>>> getBoothMap(
       @RequestParam @Min(1) int day, @RequestParam BoothType type) {

--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
@@ -25,6 +25,14 @@ public interface BoothControllerDocs {
       @RequestParam @Min(1) int day);
 
   @Operation(
+      summary = "낮/밤별 부스 목록 조회",
+      description =
+          "festivalDay + 낮/밤 타입으로 필터링한 부스 목록을 boothNumber 오름차순으로 반환합니다. "
+              + "DAY는 startTime < 16:00, NIGHT는 startTime >= 16:00 슬롯을 조회합니다.")
+  ResponseEntity<ApiResponse<List<BoothListItemResDto>>> getBoothsByDayAndType(
+      @RequestParam @Min(1) int day, @RequestParam BoothType type);
+
+  @Operation(
       summary = "부스 지도 조회",
       description =
           "festivalDay + 낮/밤 타입에 해당하는 부스 지도의 각 위치(positionNumber 1~35)에 배치된 부스 정보를 반환합니다.")

--- a/src/main/java/com/ds/dsfest/domain/booth/repository/BoothOperatingDayRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/repository/BoothOperatingDayRepository.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.booth.repository;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,18 @@ public interface BoothOperatingDayRepository extends JpaRepository<BoothOperatin
           + "WHERE od.festivalDay = :festivalDay "
           + "ORDER BY b.boothNumber ASC")
   List<BoothOperatingDay> findAllByFestivalDayWithBooth(@Param("festivalDay") int festivalDay);
+
+  @Query(
+      "SELECT DISTINCT od FROM BoothOperatingDay od "
+          + "JOIN FETCH od.booth b "
+          + "LEFT JOIN FETCH b.tags "
+          + "LEFT JOIN FETCH b.boothTypes "
+          + "WHERE od.festivalDay = :festivalDay "
+          + "  AND od.startTime >= :fromTime "
+          + "  AND od.startTime < :toTime "
+          + "ORDER BY b.boothNumber ASC")
+  List<BoothOperatingDay> findAllByFestivalDayAndTimeRange(
+      @Param("festivalDay") int festivalDay,
+      @Param("fromTime") LocalTime fromTime,
+      @Param("toTime") LocalTime toTime);
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.booth.service;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -18,11 +19,26 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class BoothService {
 
+  private static final LocalTime DAY_START = LocalTime.of(0, 0);
+  private static final LocalTime DAY_END = LocalTime.of(16, 0);
+  private static final LocalTime NIGHT_START = LocalTime.of(16, 0);
+  private static final LocalTime NIGHT_END = LocalTime.of(23, 59, 59);
+
   private final BoothOperatingDayRepository boothOperatingDayRepository;
   private final BoothMapPositionRepository boothMapPositionRepository;
 
   public List<BoothListItemResDto> getBoothsByDay(int festivalDay) {
     return boothOperatingDayRepository.findAllByFestivalDayWithBooth(festivalDay).stream()
+        .map(operatingDay -> BoothListItemResDto.from(operatingDay.getBooth(), operatingDay))
+        .toList();
+  }
+
+  public List<BoothListItemResDto> getBoothsByDayAndType(int festivalDay, BoothType type) {
+    LocalTime from = type == BoothType.DAY ? DAY_START : NIGHT_START;
+    LocalTime to = type == BoothType.DAY ? DAY_END : NIGHT_END;
+    return boothOperatingDayRepository
+        .findAllByFestivalDayAndTimeRange(festivalDay, from, to)
+        .stream()
         .map(operatingDay -> BoothListItemResDto.from(operatingDay.getBooth(), operatingDay))
         .toList();
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #12 
- #9 

## 📝 작업 내용
- 낮/밤별 부스 목록 조회 api 구현
- 일부 임포트문 conflict 해결

### 스크린샷 (선택)

## 📌 API 목록
- /api/booths/by-time
## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- 기존 부스 목록 조회 api와 유사하여 응답 dto 재사용, 필터를 추가해 확장했습니다.
시간 필터 기준

  ┌───────┬────────────────────────────────────────────────────┐
  │ type  │                        조건                        │
  ├───────┼────────────────────────────────────────────────────┤
  │ DAY   │ startTime < 16:00 (현재 데이터 기준 11:00 슬롯만)  │
  ├───────┼────────────────────────────────────────────────────┤
  │ NIGHT │ startTime >= 16:00 (현재 데이터 기준 16:00 슬롯만) │
  └───────┴────────────────────────────────────────────────────┘

  ---
  엔드포인트 정리

  ┌───────────────────────────┬─────────────────────────┬───────────┐
  │           기능            │          경로           │ 파라미터  │
  ├───────────────────────────┼─────────────────────────┼───────────┤
  │ A.5.1 DAY별 부스 목록     │ GET /api/booths         │ day       │
  ├───────────────────────────┼─────────────────────────┼───────────┤
  │ A.5.2.1 낮/밤별 부스 목록 │ GET /api/booths/by-time │ day, type │
  ├───────────────────────────┼─────────────────────────┼───────────┤
  │ A.5.2 부스 지도           │ GET /api/booths/map     │ day, type │
  └───────────────────────────┴─────────────────────────┴───────────┘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 축제 부스를 날짜 및 운영 시간대(낮/밤)로 필터링하는 새 조회 기능 추가
  * 특정 날짜에 대해 낮(오전~오후4시 미만)/밤(오후4시 이후)별 부스 조회 가능
  * 조회 결과를 부스 번호 기준 오름차순으로 정렬하여 반환

* **Documentation**
  * 해당 조회 기능이 API 문서에 추가되어 사용 방식과 정렬 기준을 안내
<!-- end of auto-generated comment: release notes by coderabbit.ai -->