### PR TITLE
Feat: 운영상태 태그 기반 필터링 부스 조회 api

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
@@ -16,6 +16,7 @@ import com.ds.dsfest.domain.booth.constant.BoothType;
 import com.ds.dsfest.domain.booth.dto.BoothDetailResDto;
 import com.ds.dsfest.domain.booth.dto.BoothListItemResDto;
 import com.ds.dsfest.domain.booth.dto.BoothMapItemResDto;
+import com.ds.dsfest.domain.booth.dto.BoothStatusItemResDto;
 import com.ds.dsfest.domain.booth.service.BoothService;
 import com.ds.dsfest.global.response.ApiResponse;
 
@@ -50,5 +51,12 @@ public class BoothController implements BoothControllerDocs {
   @GetMapping("/{boothId}")
   public ResponseEntity<ApiResponse<BoothDetailResDto>> getBoothDetail(@PathVariable Long boothId) {
     return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getBoothDetail(boothId)));
+  }
+
+  @GetMapping("/status")
+  public ResponseEntity<ApiResponse<List<BoothStatusItemResDto>>> getBoothsWithStatus(
+      @RequestParam @Min(1) int day,
+      @RequestParam(required = false, defaultValue = "false") boolean active) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getBoothsWithStatus(day, active)));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
@@ -12,6 +12,7 @@ import com.ds.dsfest.domain.booth.constant.BoothType;
 import com.ds.dsfest.domain.booth.dto.BoothDetailResDto;
 import com.ds.dsfest.domain.booth.dto.BoothListItemResDto;
 import com.ds.dsfest.domain.booth.dto.BoothMapItemResDto;
+import com.ds.dsfest.domain.booth.dto.BoothStatusItemResDto;
 import com.ds.dsfest.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,4 +49,16 @@ public interface BoothControllerDocs {
               + " 태그, 이미지, 각 운영일자의 위치 번호를 함께 반환합니다."
               + " tags 첫 번째 항목에는 현재 시각 기준 상태(운영중/운영 예정/운영 종료)가 들어갑니다.")
   ResponseEntity<ApiResponse<BoothDetailResDto>> getBoothDetail(@PathVariable Long boothId);
+
+  @Operation(
+      summary = "부스 리스트 (운영중 필터)",
+      description =
+          "festivalDay 기준 부스 목록을 각 부스의 상태(운영중/운영 예정/운영 종료)와 함께 반환합니다."
+              + " active=true 적용 시: (1) 현재 운영 중인 부스가 있으면 '운영중' 부스만,"
+              + " (2) 없고 곧 시작될 슬롯이 남아있으면 '운영 예정' 부스만(낮 종료~밤 시작 전엔 밤 부스),"
+              + " (3) 모든 슬롯 종료 후엔 빈 리스트를 반환합니다."
+              + " active=false(기본) 시 모든 부스를 상태 태그와 함께 반환합니다.")
+  ResponseEntity<ApiResponse<List<BoothStatusItemResDto>>> getBoothsWithStatus(
+      @RequestParam @Min(1) int day,
+      @RequestParam(required = false, defaultValue = "false") boolean active);
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/dto/BoothStatusItemResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/dto/BoothStatusItemResDto.java
@@ -1,0 +1,50 @@
+package com.ds.dsfest.domain.booth.dto;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ds.dsfest.domain.booth.constant.BoothType;
+import com.ds.dsfest.domain.booth.entity.Booth;
+import com.ds.dsfest.domain.booth.entity.BoothImage;
+import com.ds.dsfest.domain.booth.entity.BoothTag;
+
+public record BoothStatusItemResDto(
+    Long id,
+    int boothNumber,
+    String name,
+    Set<BoothType> boothTypes,
+    String operatingSubject,
+    String thumbnailUrl,
+    List<String> tags) {
+
+  public static BoothStatusItemResDto from(Booth booth, String statusTag) {
+    String thumbnailUrl =
+        booth.getImages().stream()
+            .min(Comparator.comparingInt(BoothImage::getImageOrder))
+            .map(BoothImage::getImageUrl)
+            .orElse(null);
+
+    List<String> tags = new ArrayList<>();
+    if (statusTag != null) {
+      tags.add(statusTag);
+    }
+    booth.getTags().stream().map(BoothTag::getTagName).forEach(tags::add);
+
+    Set<BoothType> boothTypes =
+        booth.getBoothTypes().isEmpty()
+            ? EnumSet.noneOf(BoothType.class)
+            : EnumSet.copyOf(booth.getBoothTypes());
+
+    return new BoothStatusItemResDto(
+        booth.getId(),
+        booth.getBoothNumber(),
+        booth.getName(),
+        boothTypes,
+        booth.getOperatingSubject(),
+        thumbnailUrl,
+        tags);
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -5,7 +5,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,6 +20,7 @@ import com.ds.dsfest.domain.booth.constant.BoothType;
 import com.ds.dsfest.domain.booth.dto.BoothDetailResDto;
 import com.ds.dsfest.domain.booth.dto.BoothListItemResDto;
 import com.ds.dsfest.domain.booth.dto.BoothMapItemResDto;
+import com.ds.dsfest.domain.booth.dto.BoothStatusItemResDto;
 import com.ds.dsfest.domain.booth.entity.Booth;
 import com.ds.dsfest.domain.booth.entity.BoothMapPosition;
 import com.ds.dsfest.domain.booth.entity.BoothOperatingDay;
@@ -69,6 +75,66 @@ public class BoothService {
     return boothMapPositionRepository.findAllByDayAndType(festivalDay, dayNightType).stream()
         .map(BoothMapItemResDto::from)
         .toList();
+  }
+
+  public List<BoothStatusItemResDto> getBoothsWithStatus(int festivalDay, boolean activeOnly) {
+    List<BoothOperatingDay> ods =
+        boothOperatingDayRepository.findAllByFestivalDayWithBooth(festivalDay);
+
+    Map<Long, Booth> boothsById = new LinkedHashMap<>();
+    Map<Long, List<BoothOperatingDay>> slotsByBooth = new LinkedHashMap<>();
+    for (BoothOperatingDay od : ods) {
+      Long bid = od.getBooth().getId();
+      boothsById.putIfAbsent(bid, od.getBooth());
+      slotsByBooth.computeIfAbsent(bid, k -> new ArrayList<>()).add(od);
+    }
+
+    LocalDateTime now = LocalDateTime.now(clock);
+    LocalTime effectiveTime = resolveEffectiveTime(festivalDay, now);
+
+    Map<Long, String> statusByBooth = new HashMap<>();
+    boolean anyRunning = false;
+    boolean anyUpcoming = false;
+    for (Map.Entry<Long, List<BoothOperatingDay>> e : slotsByBooth.entrySet()) {
+      boolean running = false;
+      boolean upcoming = false;
+      for (BoothOperatingDay od : e.getValue()) {
+        if (!effectiveTime.isBefore(od.getStartTime()) && effectiveTime.isBefore(od.getEndTime())) {
+          running = true;
+        } else if (effectiveTime.isBefore(od.getStartTime())) {
+          upcoming = true;
+        }
+      }
+      String s = running ? TAG_RUNNING : (upcoming ? TAG_UPCOMING : TAG_ENDED);
+      statusByBooth.put(e.getKey(), s);
+      if (running) anyRunning = true;
+      if (upcoming) anyUpcoming = true;
+    }
+
+    if (activeOnly) {
+      String filterStatus = anyRunning ? TAG_RUNNING : (anyUpcoming ? TAG_UPCOMING : null);
+      if (filterStatus == null) {
+        return List.of();
+      }
+      return boothsById.values().stream()
+          .filter(b -> filterStatus.equals(statusByBooth.get(b.getId())))
+          .sorted(Comparator.comparingInt(Booth::getBoothNumber))
+          .map(b -> BoothStatusItemResDto.from(b, statusByBooth.get(b.getId())))
+          .toList();
+    }
+
+    return boothsById.values().stream()
+        .sorted(Comparator.comparingInt(Booth::getBoothNumber))
+        .map(b -> BoothStatusItemResDto.from(b, statusByBooth.get(b.getId())))
+        .toList();
+  }
+
+  private LocalTime resolveEffectiveTime(int festivalDay, LocalDateTime now) {
+    long diff = ChronoUnit.DAYS.between(festivalStartDate, now.toLocalDate());
+    int todayFestivalDay = (int) diff + 1;
+    if (festivalDay > todayFestivalDay) return LocalTime.MIN;
+    if (festivalDay < todayFestivalDay) return LocalTime.MAX;
+    return now.toLocalTime();
   }
 
   public BoothDetailResDto getBoothDetail(Long boothId) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #16 

## 📝 작업 내용
- tag(운영중, 운영 예정, 운영 종료) 와 함께 부스 목록 조회
- 운영중 필터링 기능 추가

### 스크린샷 (선택)

## 📌 API 목록
- /api/booths/status

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
[현재 시각 기준 부스 노출 로직]

- 낮부스 시간 (11:00~14:30)
  - active=false: 전체 부스 (각 상태 태그)
  - active=true: 운영중 부스만

- 낮 종료 ~ 밤 시작 전 (14:30~16:00)
  - active=false: 전체 부스
  - active=true: 운영 예정 부스만 (밤 부스)

- 밤부스 시간 (16:00~19:30)
  - active=false: 전체 부스
  - active=true: 운영중 부스만

- 밤 종료 후 (19:30~)
  - active=false: 전체 부스
  - active=true: 빈 리스트

- 낮부스 시작 전 (~11:00)
  - active=false: 전체 부스
  - active=true: 운영 예정 부스만 (낮 부스)


[부스별 status 판정 기준 (요청 day vs 오늘 비교)]

- day > today (미래 일자)
  - effectiveTime: 00:00
  - 효과: 모든 슬롯이 upcoming → 전부 운영 예정

- day < today (과거 일자)
  - effectiveTime: 23:59
  - 효과: 모든 슬롯이 past → 전부 운영 종료

- day == today
  - effectiveTime: 실제 현재 시각
  - 효과: 위 로직대로 판정
  변경 파일

  - 신규: BoothStatusItemResDto.java
  - 수정: BoothService.java (getBoothsWithStatus + resolveEffectiveTime), BoothController.java (GET /status), BoothControllerDocs.java


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 부스 상태 조회 기능이 추가되었습니다. 축제 특정 날짜에서 각 부스의 운영 상태(운영 중/예정/종료)를 확인할 수 있습니다. 선택적 필터를 통해 현재 운영 중인 부스만 조회하거나 전체 부스를 확인할 수 있으며, 부스 번호 순서로 정렬된 결과를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->