### PR TITLE
Feat: 부스 랜덤 추천 api

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothController.java
@@ -59,4 +59,10 @@ public class BoothController implements BoothControllerDocs {
       @RequestParam(required = false, defaultValue = "false") boolean active) {
     return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getBoothsWithStatus(day, active)));
   }
+
+  @GetMapping("/random")
+  public ResponseEntity<ApiResponse<BoothStatusItemResDto>> getRandomRecommendedBooth(
+      @RequestParam @Min(1) int day) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(boothService.getRandomRecommendedBooth(day)));
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
@@ -61,4 +61,11 @@ public interface BoothControllerDocs {
   ResponseEntity<ApiResponse<List<BoothStatusItemResDto>>> getBoothsWithStatus(
       @RequestParam @Min(1) int day,
       @RequestParam(required = false, defaultValue = "false") boolean active);
+
+  @Operation(
+      summary = "랜덤 부스 추천",
+      description =
+          "festivalDay 기준 현재 '운영중' 상태인 부스 중 무작위 1개를 반환합니다." + " 운영중인 부스가 하나도 없으면 result가 null입니다.")
+  ResponseEntity<ApiResponse<BoothStatusItemResDto>> getRandomRecommendedBooth(
+      @RequestParam @Min(1) int day);
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -54,6 +55,7 @@ public class BoothService {
   private LocalDate festivalStartDate;
 
   private final Clock clock = Clock.systemDefaultZone();
+  private final Random random = new Random();
 
   public List<BoothListItemResDto> getBoothsByDay(int festivalDay) {
     return boothOperatingDayRepository.findAllByFestivalDayWithBooth(festivalDay).stream()
@@ -127,6 +129,17 @@ public class BoothService {
         .sorted(Comparator.comparingInt(Booth::getBoothNumber))
         .map(b -> BoothStatusItemResDto.from(b, statusByBooth.get(b.getId())))
         .toList();
+  }
+
+  public BoothStatusItemResDto getRandomRecommendedBooth(int festivalDay) {
+    List<BoothStatusItemResDto> running = new ArrayList<>();
+    for (BoothStatusItemResDto b : getBoothsWithStatus(festivalDay, false)) {
+      if (!b.tags().isEmpty() && TAG_RUNNING.equals(b.tags().get(0))) {
+        running.add(b);
+      }
+    }
+    if (running.isEmpty()) return null;
+    return running.get(random.nextInt(running.size()));
   }
 
   private LocalTime resolveEffectiveTime(int festivalDay, LocalDateTime now) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #18 

## 📝 작업 내용
- 랜덤 부스 추천 api 구현(운영중 태그인 것들 중에서만)

### 스크린샷 (선택)

## 📌 API 목록
- /api/booths/random

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)

  - 운영중 상태인 부스들을 후보로 수집
  - 운영 예정, 운영 종료 부스는 제외
  - Collections.shuffle로 무작위 섞은 뒤 1개 반환
  - 후보가 없으면 빈 값



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 축제 날짜에 운영 중인 부스 중 랜덤으로 추천 부스를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 운영 중인 부스가 없을 경우 결과는 null로 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->