### PR TITLE
Feat: 실시간 축제 상태 조회 api

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/dto/BoothListItemResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/dto/BoothListItemResDto.java
@@ -1,6 +1,6 @@
 package com.ds.dsfest.domain.booth.dto;
 
-import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -20,10 +20,11 @@ public record BoothListItemResDto(
     String operatingSubject,
     String thumbnailUrl,
     List<String> tags,
-    LocalTime startTime,
-    LocalTime endTime) {
+    List<String> operatingTimes) {
 
-  public static BoothListItemResDto from(Booth booth, BoothOperatingDay operatingDay) {
+  private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+  public static BoothListItemResDto from(Booth booth, List<BoothOperatingDay> operatingDays) {
     String thumbnailUrl =
         booth.getImages().stream()
             .min(Comparator.comparingInt(BoothImage::getImageOrder))
@@ -37,6 +38,13 @@ public record BoothListItemResDto(
             ? EnumSet.noneOf(BoothType.class)
             : EnumSet.copyOf(booth.getBoothTypes());
 
+    List<String> operatingTimes =
+        operatingDays.stream()
+            .sorted(Comparator.comparing(BoothOperatingDay::getStartTime))
+            .map(od -> od.getStartTime().format(TIME_FMT) + "~" + od.getEndTime().format(TIME_FMT))
+            .distinct()
+            .toList();
+
     return new BoothListItemResDto(
         booth.getId(),
         booth.getBoothNumber(),
@@ -45,7 +53,6 @@ public record BoothListItemResDto(
         booth.getOperatingSubject(),
         thumbnailUrl,
         tags,
-        operatingDay.getStartTime(),
-        operatingDay.getEndTime());
+        operatingTimes);
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -50,11 +50,11 @@ public class BoothService {
   private final BoothRepository boothRepository;
   private final BoothOperatingDayRepository boothOperatingDayRepository;
   private final BoothMapPositionRepository boothMapPositionRepository;
+  private final Clock clock;
 
   @Value("${festival.start-date}")
   private LocalDate festivalStartDate;
 
-  private final Clock clock = Clock.systemDefaultZone();
   private final Random random = new Random();
 
   public List<BoothListItemResDto> getBoothsByDay(int festivalDay) {

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -58,18 +58,30 @@ public class BoothService {
   private final Random random = new Random();
 
   public List<BoothListItemResDto> getBoothsByDay(int festivalDay) {
-    return boothOperatingDayRepository.findAllByFestivalDayWithBooth(festivalDay).stream()
-        .map(operatingDay -> BoothListItemResDto.from(operatingDay.getBooth(), operatingDay))
-        .toList();
+    return groupAndMap(boothOperatingDayRepository.findAllByFestivalDayWithBooth(festivalDay));
   }
 
   public List<BoothListItemResDto> getBoothsByDayAndType(int festivalDay, BoothType type) {
     LocalTime from = type == BoothType.DAY ? DAY_START : NIGHT_START;
     LocalTime to = type == BoothType.DAY ? DAY_END : NIGHT_END;
-    return boothOperatingDayRepository
-        .findAllByFestivalDayAndTimeRange(festivalDay, from, to)
-        .stream()
-        .map(operatingDay -> BoothListItemResDto.from(operatingDay.getBooth(), operatingDay))
+    return groupAndMap(
+        boothOperatingDayRepository.findAllByFestivalDayAndTimeRange(festivalDay, from, to));
+  }
+
+  private List<BoothListItemResDto> groupAndMap(List<BoothOperatingDay> ods) {
+    Map<Long, Booth> boothsById = new LinkedHashMap<>();
+    Map<Long, List<BoothOperatingDay>> slotsByBooth = new LinkedHashMap<>();
+    for (BoothOperatingDay od : ods) {
+      Long bid = od.getBooth().getId();
+      boothsById.putIfAbsent(bid, od.getBooth());
+      List<BoothOperatingDay> slots = slotsByBooth.computeIfAbsent(bid, k -> new ArrayList<>());
+      if (!slots.contains(od)) {
+        slots.add(od);
+      }
+    }
+    return boothsById.values().stream()
+        .sorted(Comparator.comparingInt(Booth::getBoothNumber))
+        .map(b -> BoothListItemResDto.from(b, slotsByBooth.get(b.getId())))
         .toList();
   }
 

--- a/src/main/java/com/ds/dsfest/domain/schedule/constant/FestivalStatus.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/constant/FestivalStatus.java
@@ -1,0 +1,7 @@
+package com.ds.dsfest.domain.schedule.constant;
+
+public enum FestivalStatus {
+  IN_PROGRESS,
+  UPCOMING,
+  ENDED
+}

--- a/src/main/java/com/ds/dsfest/domain/schedule/controller/FestivalScheduleController.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/controller/FestivalScheduleController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ds.dsfest.domain.schedule.dto.FestivalScheduleDayResDto;
+import com.ds.dsfest.domain.schedule.dto.FestivalScheduleNowResDto;
 import com.ds.dsfest.domain.schedule.service.FestivalScheduleService;
 import com.ds.dsfest.global.response.ApiResponse;
 
@@ -23,5 +24,10 @@ public class FestivalScheduleController implements FestivalScheduleControllerDoc
   @GetMapping
   public ResponseEntity<ApiResponse<List<FestivalScheduleDayResDto>>> getAllSchedules() {
     return ResponseEntity.ok(ApiResponse.onSuccess(festivalScheduleService.getAllSchedules()));
+  }
+
+  @GetMapping("/now")
+  public ResponseEntity<ApiResponse<FestivalScheduleNowResDto>> getCurrentStatus() {
+    return ResponseEntity.ok(ApiResponse.onSuccess(festivalScheduleService.getCurrentStatus()));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/schedule/controller/FestivalScheduleControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/controller/FestivalScheduleControllerDocs.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 import com.ds.dsfest.domain.schedule.dto.FestivalScheduleDayResDto;
+import com.ds.dsfest.domain.schedule.dto.FestivalScheduleNowResDto;
 import com.ds.dsfest.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,4 +20,13 @@ public interface FestivalScheduleControllerDocs {
           "festivalDay별로 그룹핑된 전체 축제 일정을 반환합니다. 각 그룹은 festivalDay 오름차순,"
               + " 그룹 내 일정은 startTime 오름차순으로 정렬됩니다.")
   ResponseEntity<ApiResponse<List<FestivalScheduleDayResDto>>> getAllSchedules();
+
+  @Operation(
+      summary = "실시간 축제 상태 조회",
+      description =
+          "현재 시각 기준으로 축제 진행 상태를 반환합니다. "
+              + "IN_PROGRESS: current 배열에 현재 진행 중인 일정들. "
+              + "UPCOMING: next에 다음에 시작될 일정 1건. "
+              + "ENDED: 축제가 모두 종료되었음(또는 아직 일정이 등록되지 않음).")
+  ResponseEntity<ApiResponse<FestivalScheduleNowResDto>> getCurrentStatus();
 }

--- a/src/main/java/com/ds/dsfest/domain/schedule/dto/FestivalScheduleNowResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/dto/FestivalScheduleNowResDto.java
@@ -1,0 +1,21 @@
+package com.ds.dsfest.domain.schedule.dto;
+
+import java.util.List;
+
+import com.ds.dsfest.domain.schedule.constant.FestivalStatus;
+
+public record FestivalScheduleNowResDto(
+    FestivalStatus status, List<ScheduleItemResDto> current, ScheduleItemResDto next) {
+
+  public static FestivalScheduleNowResDto inProgress(List<ScheduleItemResDto> current) {
+    return new FestivalScheduleNowResDto(FestivalStatus.IN_PROGRESS, current, null);
+  }
+
+  public static FestivalScheduleNowResDto upcoming(ScheduleItemResDto next) {
+    return new FestivalScheduleNowResDto(FestivalStatus.UPCOMING, List.of(), next);
+  }
+
+  public static FestivalScheduleNowResDto ended() {
+    return new FestivalScheduleNowResDto(FestivalStatus.ENDED, List.of(), null);
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/schedule/service/FestivalScheduleService.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/service/FestivalScheduleService.java
@@ -28,11 +28,10 @@ import lombok.RequiredArgsConstructor;
 public class FestivalScheduleService {
 
   private final FestivalScheduleRepository festivalScheduleRepository;
+  private final Clock clock;
 
   @Value("${festival.start-date}")
   private LocalDate festivalStartDate;
-
-  private final Clock clock = Clock.systemDefaultZone();
 
   public List<FestivalScheduleDayResDto> getAllSchedules() {
     List<FestivalSchedule> all =

--- a/src/main/java/com/ds/dsfest/domain/schedule/service/FestivalScheduleService.java
+++ b/src/main/java/com/ds/dsfest/domain/schedule/service/FestivalScheduleService.java
@@ -1,17 +1,21 @@
 package com.ds.dsfest.domain.schedule.service;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ds.dsfest.domain.schedule.dto.FestivalScheduleDayResDto;
+import com.ds.dsfest.domain.schedule.dto.FestivalScheduleNowResDto;
 import com.ds.dsfest.domain.schedule.dto.ScheduleItemResDto;
 import com.ds.dsfest.domain.schedule.entity.FestivalSchedule;
 import com.ds.dsfest.domain.schedule.repository.FestivalScheduleRepository;
@@ -27,6 +31,8 @@ public class FestivalScheduleService {
 
   @Value("${festival.start-date}")
   private LocalDate festivalStartDate;
+
+  private final Clock clock = Clock.systemDefaultZone();
 
   public List<FestivalScheduleDayResDto> getAllSchedules() {
     List<FestivalSchedule> all =
@@ -55,6 +61,33 @@ public class FestivalScheduleService {
       result.add(new FestivalScheduleDayResDto(e.getKey(), date, label, e.getValue()));
     }
     return result;
+  }
+
+  public FestivalScheduleNowResDto getCurrentStatus() {
+    LocalDateTime now = LocalDateTime.now(clock);
+    List<FestivalSchedule> all =
+        festivalScheduleRepository.findAllByOrderByFestivalDayAscStartTimeAsc();
+
+    if (all.isEmpty()) {
+      return FestivalScheduleNowResDto.ended();
+    }
+
+    List<ScheduleItemResDto> active =
+        all.stream()
+            .filter(s -> !s.getStartTime().isAfter(now))
+            .filter(s -> s.getEndTime() == null || s.getEndTime().isAfter(now))
+            .map(ScheduleItemResDto::from)
+            .toList();
+
+    if (!active.isEmpty()) {
+      return FestivalScheduleNowResDto.inProgress(active);
+    }
+
+    Optional<FestivalSchedule> next =
+        all.stream().filter(s -> s.getStartTime().isAfter(now)).findFirst();
+
+    return next.map(s -> FestivalScheduleNowResDto.upcoming(ScheduleItemResDto.from(s)))
+        .orElseGet(FestivalScheduleNowResDto::ended);
   }
 
   private String toKoreanDow(DayOfWeek dow) {

--- a/src/main/java/com/ds/dsfest/global/config/ClockConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/ClockConfig.java
@@ -1,0 +1,18 @@
+package com.ds.dsfest.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+  private static final ZoneId FESTIVAL_ZONE = ZoneId.of("Asia/Seoul");
+
+  @Bean
+  public Clock festivalClock() {
+    return Clock.system(FESTIVAL_ZONE);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #22 
- #21 

## 📝 작업 내용
- 축제 전체 타임라인에서 현재 시각 진행중인 활동 반환
- 현재 시각 기준 필터링(Asia/Seoul로 clock 의존성 주입해 고정)

### 스크린샷 (선택)

## 📌 API 목록
- /api/schedules/now

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-판정 로직

  1. 전체 일정을 startTime 오름차순으로 조회
  2. 현재 진행 중: startTime ≤ now AND (endTime IS NULL OR endTime > now) → 여러 건 가능 (낮 부스 + 무대 리허설 등 동시 진행)
  3. 없으면 다음 예정: startTime > now인 가장 빠른 1건
  4. 둘 다 없으면 종료

IN_PROGRESS: current 배열에 현재 진행 중인 일정들. 

UPCOMING: next에 다음에 시작될 일정 1건. 

ENDED: 축제가 모두 종료되었음(또는 아직 일정이 등록되지 않음).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 축제 현재 상태 조회 API 추가: 진행 중(IN_PROGRESS)/예정(UPCOMING)/종료(ENDED) 및 현재/다음 일정 정보 제공.
* **변경**
  * 일정 응답이 상태별로 현재 일정 목록과 다음 일정 항목을 포함하여 반환됨.
  * 부스 목록의 운영 시간 표시 방식이 개별 운영시간 문자열 목록("HH:mm~HH:mm")으로 변경됨.
* **설정**
  * 애플리케이션의 기준 시간이 Asia/Seoul 클록으로 일관화됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->