### PR TITLE
Feat: 태그 기반 부스 조회 시 정렬 추가

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -95,23 +95,35 @@ public class BoothService {
     LocalTime effectiveTime = resolveEffectiveTime(festivalDay, now);
 
     Map<Long, String> statusByBooth = new HashMap<>();
+    Map<Long, LocalTime> earliestUpcomingByBooth = new HashMap<>();
     boolean anyRunning = false;
     boolean anyUpcoming = false;
     for (Map.Entry<Long, List<BoothOperatingDay>> e : slotsByBooth.entrySet()) {
       boolean running = false;
-      boolean upcoming = false;
+      LocalTime earliestUpcoming = null;
       for (BoothOperatingDay od : e.getValue()) {
         if (!effectiveTime.isBefore(od.getStartTime()) && effectiveTime.isBefore(od.getEndTime())) {
           running = true;
         } else if (effectiveTime.isBefore(od.getStartTime())) {
-          upcoming = true;
+          if (earliestUpcoming == null || od.getStartTime().isBefore(earliestUpcoming)) {
+            earliestUpcoming = od.getStartTime();
+          }
         }
       }
+      boolean upcoming = earliestUpcoming != null;
       String s = running ? TAG_RUNNING : (upcoming ? TAG_UPCOMING : TAG_ENDED);
       statusByBooth.put(e.getKey(), s);
+      if (upcoming) earliestUpcomingByBooth.put(e.getKey(), earliestUpcoming);
       if (running) anyRunning = true;
       if (upcoming) anyUpcoming = true;
     }
+
+    Comparator<Booth> statusComparator =
+        Comparator.<Booth, Integer>comparing(b -> statusPriority(statusByBooth.get(b.getId())))
+            .thenComparing(
+                b -> earliestUpcomingByBooth.getOrDefault(b.getId(), LocalTime.MIN),
+                Comparator.naturalOrder())
+            .thenComparingInt(Booth::getBoothNumber);
 
     if (activeOnly) {
       String filterStatus = anyRunning ? TAG_RUNNING : (anyUpcoming ? TAG_UPCOMING : null);
@@ -120,15 +132,21 @@ public class BoothService {
       }
       return boothsById.values().stream()
           .filter(b -> filterStatus.equals(statusByBooth.get(b.getId())))
-          .sorted(Comparator.comparingInt(Booth::getBoothNumber))
+          .sorted(statusComparator)
           .map(b -> BoothStatusItemResDto.from(b, statusByBooth.get(b.getId())))
           .toList();
     }
 
     return boothsById.values().stream()
-        .sorted(Comparator.comparingInt(Booth::getBoothNumber))
+        .sorted(statusComparator)
         .map(b -> BoothStatusItemResDto.from(b, statusByBooth.get(b.getId())))
         .toList();
+  }
+
+  private int statusPriority(String status) {
+    if (TAG_RUNNING.equals(status)) return 0;
+    if (TAG_UPCOMING.equals(status)) return 1;
+    return 2;
   }
 
   public BoothStatusItemResDto getRandomRecommendedBooth(int festivalDay) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #16 

## 📝 작업 내용
- 부스 목록 조회 시 정렬 기능 추가

### 스크린샷 (선택)

## 📌 API 목록
추가x


## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-  정렬 규칙                                                                                                                                                                                                   
                                                                                                                                                                                                              
  1차: status 우선순위                                                                                                                                                                                        
                                                                                                                                                                                                              
  ┌──────┬───────────┐                                                                                                                                                                                      
  │        순서 │             태그         │                                                                                                                                                                                        
  ├──────┼───────────┤
  │ 1             │              운영중    │                                                                                                                                                                                        
  ├──────┼───────────┤                                                                                                                                                                                        
  │ 2             │      운영 예정       │
  ├──────┼───────────┤
  │ 3             │      운영 종료       │
  └──────┴───────────┘

  2차: 운영 예정 그룹 내부 — 가장 빨리 시작하는 슬롯 기준 오름차순
  - 예) 16:00 시작 부스 < 17:00 시작 부스

  3차: 동점 시 boothNumber 오름차순 (tiebreaker)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 내용

* **개선 사항**
  * 부스 목록 정렬 순서 개선: 부스가 진행 중 → 예정 → 종료 순으로 표시됩니다.
  * 예정된 부스의 가장 빠른 시작 시간을 기준으로 우선순위 조정
  * 같은 상태의 부스는 부스 번호로 정렬되어 더 나은 사용자 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->