### PR TITLE
Fix: DAY별 부스 조회 중복 에러 수정

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/repository/BoothOperatingDayRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/repository/BoothOperatingDayRepository.java
@@ -1,13 +1,11 @@
 package com.ds.dsfest.domain.booth.repository;
 
-import java.time.LocalTime;
-import java.util.List;
-
 import com.ds.dsfest.domain.booth.entity.BoothOperatingDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalTime;
 import java.util.List;
 
 public interface BoothOperatingDayRepository extends JpaRepository<BoothOperatingDay, Long> {
@@ -17,7 +15,6 @@ public interface BoothOperatingDayRepository extends JpaRepository<BoothOperatin
           + "JOIN FETCH od.booth b "
           + "LEFT JOIN FETCH b.tags "
           + "LEFT JOIN FETCH b.boothTypes "
-          + "LEFT JOIN FETCH b.images "
           + "WHERE od.festivalDay = :festivalDay "
           + "ORDER BY b.boothNumber ASC")
   List<BoothOperatingDay> findAllByFestivalDayWithBooth(@Param("festivalDay") int festivalDay);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #26 

## 📝 작업 내용
- DAY별 부스 목록 조회 시 같은 부스 여러 번 조회되는 에러 수정

### 스크린샷 (선택)

## 📌 API 목록

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
 수정
                                                                                                                                                                                                              
  - b.images JOIN FETCH 제거 (tags 유지)                                                                                                                                                                      
  - 중복 import java.util.List; 제거 + import 순서 정리                                                                                                                                                       

  영향

  - images(썸네일)는 lazy 로딩으로 전환 → 리스트 엔드포인트에서 부스 수 × 1 query N+1 발생 가능. 현재 약 70개 부스라 실사용엔 문제 없음. 성능이 중요해지면 @BatchSize(size=50) 을 Booth.images 필드에 추가하는
   게 간단한 튜닝 방법.
  - 로직/응답 형태 변화 없음.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **최적화**
  * 부스 운영일 조회 성능을 개선하였습니다. 이미지 데이터는 필요에 따라 별도로 로드됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->