### PR TITLE
Feat: 아티스트 목록 조회,상세,플리

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistController.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistController.java
@@ -1,0 +1,35 @@
+package com.ds.dsfest.domain.artist.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.ds.dsfest.domain.artist.dto.ArtistListResponseDto;
+import com.ds.dsfest.domain.artist.dto.ArtistPlaylistResponseDto;
+import com.ds.dsfest.domain.artist.service.ArtistService;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/artists")
+public class ArtistController implements ArtistControllerDocs {
+
+  private final ArtistService artistService;
+
+  @Override
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<ArtistListResponseDto>>> getArtistsByDay(
+      @RequestParam int day) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(artistService.getArtistsByDay(day)));
+  }
+
+  @Override
+  @GetMapping("/{artistId}/playlist")
+  public ResponseEntity<ApiResponse<ArtistPlaylistResponseDto>> getArtistPlaylist(
+      @PathVariable Long artistId) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(artistService.getArtistPlaylist(artistId)));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistControllerDocs.java
@@ -1,0 +1,22 @@
+package com.ds.dsfest.domain.artist.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.ds.dsfest.domain.artist.dto.ArtistListResponseDto;
+import com.ds.dsfest.domain.artist.dto.ArtistPlaylistResponseDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Artist", description = "아티스트 관련 API")
+public interface ArtistControllerDocs {
+
+  @Operation(summary = "DAY별 아티스트 목록 조회", description = "특정 DAY에 해당하는 아티스트 목록을 조회합니다.")
+  ResponseEntity<ApiResponse<List<ArtistListResponseDto>>> getArtistsByDay(int day);
+
+  @Operation(summary = "덕우들의 플레이리스트 조회", description = "아티스트의 유튜브 플레이리스트 링크를 조회합니다.")
+  ResponseEntity<ApiResponse<ArtistPlaylistResponseDto>> getArtistPlaylist(Long artistId);
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/dto/ArtistListResponseDto.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/dto/ArtistListResponseDto.java
@@ -1,0 +1,29 @@
+package com.ds.dsfest.domain.artist.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.ds.dsfest.domain.artist.entity.CountdownStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArtistListResponseDto {
+
+  private Long id;
+  private String name;
+  private String shortBio;
+
+  private int festivalDay;
+  private LocalDate performanceDate;
+  private LocalTime startTime;
+  private LocalTime endTime;
+
+  private String imageUrl;
+  private String instagramUrl;
+  private String youtubeUrl;
+
+  private CountdownStatus countdownStatus;
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/dto/ArtistPlaylistResponseDto.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/dto/ArtistPlaylistResponseDto.java
@@ -1,0 +1,14 @@
+package com.ds.dsfest.domain.artist.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+// 덕우플레이리스트
+public class ArtistPlaylistResponseDto {
+
+  private Long artistId;
+  private String artistName;
+  private String youtubeUrl;
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/entity/CountdownStatus.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/entity/CountdownStatus.java
@@ -1,0 +1,8 @@
+package com.ds.dsfest.domain.artist.entity;
+
+public enum CountdownStatus {
+  MORE_THAN_24H,
+  WITHIN_24H,
+  LIVE,
+  ENDED
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/exception/ArtistErrorCode.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/exception/ArtistErrorCode.java
@@ -1,0 +1,18 @@
+package com.ds.dsfest.domain.artist.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.ds.dsfest.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtistErrorCode implements BaseErrorCode {
+  ARTIST_NOT_FOUND("ARTIST001", "해당 아티스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/repository/ArtistRepository.java
@@ -1,0 +1,13 @@
+package com.ds.dsfest.domain.artist.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ds.dsfest.domain.artist.entity.Artist;
+
+public interface ArtistRepository extends JpaRepository<Artist, Long> {
+
+  // DAY별 아티스트 조회 (시간순 정렬)
+  List<Artist> findByFestivalDayOrderByStartTimeAsc(int festivalDay);
+}

--- a/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
@@ -1,0 +1,88 @@
+package com.ds.dsfest.domain.artist.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ds.dsfest.domain.artist.dto.ArtistListResponseDto;
+import com.ds.dsfest.domain.artist.dto.ArtistPlaylistResponseDto;
+import com.ds.dsfest.domain.artist.entity.Artist;
+import com.ds.dsfest.domain.artist.entity.CountdownStatus;
+import com.ds.dsfest.domain.artist.exception.ArtistErrorCode;
+import com.ds.dsfest.domain.artist.repository.ArtistRepository;
+import com.ds.dsfest.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistService {
+
+  private final ArtistRepository artistRepository;
+
+  public List<ArtistListResponseDto> getArtistsByDay(int day) {
+    List<Artist> artists = artistRepository.findByFestivalDayOrderByStartTimeAsc(day);
+
+    return artists.stream()
+        .map(
+            artist ->
+                ArtistListResponseDto.builder()
+                    .id(artist.getId())
+                    .name(artist.getName())
+                    .shortBio(artist.getShortBio())
+                    .imageUrl(artist.getImageUrl())
+                    .festivalDay(artist.getFestivalDay())
+                    .performanceDate(artist.getPerformanceDate())
+                    .startTime(artist.getStartTime())
+                    .endTime(artist.getEndTime())
+                    .instagramUrl(artist.getInstagramUrl())
+                    .youtubeUrl(artist.getYoutubeUrl())
+                    .countdownStatus(calculateCountdownStatus(artist))
+                    .build())
+        .toList();
+  }
+
+  public ArtistPlaylistResponseDto getArtistPlaylist(Long artistId) {
+    Artist artist = getArtistById(artistId);
+
+    return ArtistPlaylistResponseDto.builder()
+        .artistId(artist.getId())
+        .artistName(artist.getName())
+        .youtubeUrl(artist.getYoutubeUrl())
+        .build();
+  }
+
+  private Artist getArtistById(Long artistId) {
+    return artistRepository
+        .findById(artistId)
+        .orElseThrow(() -> new CustomException(ArtistErrorCode.ARTIST_NOT_FOUND));
+  }
+
+  private CountdownStatus calculateCountdownStatus(Artist artist) {
+    LocalDateTime now = LocalDateTime.now();
+
+    LocalDateTime start = LocalDateTime.of(artist.getPerformanceDate(), artist.getStartTime());
+
+    LocalDateTime end = LocalDateTime.of(artist.getPerformanceDate(), artist.getEndTime());
+
+    if (now.isAfter(end)) {
+      return CountdownStatus.ENDED;
+    }
+
+    if ((now.isEqual(start) || now.isAfter(start)) && now.isBefore(end)) {
+      return CountdownStatus.LIVE;
+    }
+
+    Duration duration = Duration.between(now, start);
+
+    if (duration.toHours() <= 24) {
+      return CountdownStatus.WITHIN_24H;
+    }
+
+    return CountdownStatus.MORE_THAN_24H;
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) close #7 

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
아티스트 목록, 아티스트 상세, 플레이리스트 

### 스크린샷 (선택)

## 📌 API 목록
/api/artists - day별 아티스트 목록 & 각 아티스트 세부 정보
/api/artists/{artistId}/playlist - 아티스트별 재생목록
<img width="733" height="226" alt="스크린샷 2026-04-21 223914" src="https://github.com/user-attachments/assets/7de2471c-a6a0-4684-b5cf-e1d9ab444146" />


## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공연일별 아티스트 목록 조회 기능 추가
  * 아티스트 유튜브 플레이리스트 조회 기능 추가
  * 공연 카운트다운 상태 표시 기능 추가 (24시간 이상, 24시간 이내, 라이브, 종료)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->