### PR TITLE
Feat: 푸드트럭 배너 조회 api 구현

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
@@ -1,0 +1,28 @@
+package com.ds.dsfest.domain.foodtruck.controller;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckBannerResDto;
+import com.ds.dsfest.domain.foodtruck.service.FoodTruckBannerService;
+import com.ds.dsfest.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/food-trucks/banners")
+public class FoodTruckBannerController implements FoodTruckBannerControllerDocs {
+
+    private final FoodTruckBannerService foodTruckBannerService;
+
+    @GetMapping
+    @Override
+    public ResponseEntity<ApiResponse<List<FoodTruckBannerResDto>>> getFoodTruckBanners() {
+        List<FoodTruckBannerResDto> response = foodTruckBannerService.getFoodTruckBanners();
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * 푸드트럭 배너 API 컨트롤러 구현체
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/food-trucks/banners")
@@ -18,6 +21,9 @@ public class FoodTruckBannerController implements FoodTruckBannerControllerDocs 
 
     private final FoodTruckBannerService foodTruckBannerService;
 
+    /**
+     * 배너 목록 조회 API
+     */
     @GetMapping
     @Override
     public ResponseEntity<ApiResponse<List<FoodTruckBannerResDto>>> getFoodTruckBanners() {

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerControllerDocs.java
@@ -1,0 +1,16 @@
+package com.ds.dsfest.domain.foodtruck.controller;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckBannerResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "FoodTruck", description = "푸드트럭 관련 API")
+public interface FoodTruckBannerControllerDocs {
+
+    @Operation(summary = "푸드트럭 배너 목록 조회", description = "푸드트럭 탭 상단에 표시될 배너 목록을 순서대로 조회합니다.")
+    ResponseEntity<ApiResponse<List<FoodTruckBannerResDto>>> getFoodTruckBanners();
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckBannerResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckBannerResDto.java
@@ -1,0 +1,8 @@
+package com.ds.dsfest.domain.foodtruck.dto;
+
+public record FoodTruckBannerResDto(
+    Long id,
+    String imageUrl,
+    String title
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckBannerResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckBannerResDto.java
@@ -1,5 +1,8 @@
 package com.ds.dsfest.domain.foodtruck.dto;
 
+/**
+ * 푸드트럭 탭 상단 배너 응답을 위한 DTO
+ */
 public record FoodTruckBannerResDto(
     Long id,
     String imageUrl,

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckBanner.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckBanner.java
@@ -28,4 +28,7 @@ public class FoodTruckBanner extends BaseEntity {
 
   @Column(nullable = false)
   private int bannerOrder;
+
+  @Column(name = "title", nullable = false, length = 100)
+  private String title;
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckBannerMapper.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckBannerMapper.java
@@ -1,0 +1,20 @@
+package com.ds.dsfest.domain.foodtruck.mapper;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckBannerResDto;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckBanner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FoodTruckBannerMapper {
+
+    /**
+     * FoodTruckBanner 엔티티를 응답 DTO로 변환
+     */
+    public FoodTruckBannerResDto toResDto(FoodTruckBanner banner) {
+        return new FoodTruckBannerResDto(
+            banner.getId(),
+            banner.getImageUrl(),
+            banner.getTitle()
+        );
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckBannerRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckBannerRepository.java
@@ -1,0 +1,13 @@
+package com.ds.dsfest.domain.foodtruck.repository;
+
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckBanner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface FoodTruckBannerRepository extends JpaRepository<FoodTruckBanner, Long> {
+
+    /**
+     * 배너를 순서(bannerOrder) 오름차순으로 모두 가져오는 쿼리 메서드
+     */
+    List<FoodTruckBanner> findAllByOrderByBannerOrderAsc();
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckBannerService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckBannerService.java
@@ -1,0 +1,30 @@
+package com.ds.dsfest.domain.foodtruck.service;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckBannerResDto;
+import com.ds.dsfest.domain.foodtruck.mapper.FoodTruckBannerMapper;
+import com.ds.dsfest.domain.foodtruck.repository.FoodTruckBannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FoodTruckBannerService {
+
+    private final FoodTruckBannerRepository foodTruckBannerRepository;
+    private final FoodTruckBannerMapper foodTruckBannerMapper;
+
+    /**
+     * 푸드트럭 배너 목록을 순서대로 조회하여 DTO로 반환합니다.
+     */
+    public List<FoodTruckBannerResDto> getFoodTruckBanners() {
+        return foodTruckBannerRepository.findAllByOrderByBannerOrderAsc()
+            .stream()
+            .map(foodTruckBannerMapper::toResDto)
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
- FoodTruckBanner 엔티티(title 추가)

## #️⃣ 연관된 이슈
- close #34

## 📝 작업 내용
- 푸드트럭 메인 탭 상단에 노출될 롤링 배너 목록 조회 API를 구현했습니다. 
- **[구조 개선]** `FoodTruckBanner` 엔티티에 `title` 컬럼을 추가했습니다.(ex-"직화 닭꼬치 어때요?")
- 배너 노출 순서(`bannerOrder`)에 따라 오름차순으로 정렬하여 응답하도록 Repository 쿼리 메서드를 작성했습니다.
- Swagger Docs 어노테이션을 통해 API 문서화를 완료했습니다.

## 📌 API 목록
- `GET /api/v1/food-trucks/banners`

## 💡 프론트엔드 참고 사항
- 응답 값에 `imageUrl`과 함께 `title`(예: "직화 닭꼬치 어때요?")이 포함되어 내려갑니다. 배너 렌더링 시 해당 텍스트 데이터를 활용해 주세요!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 푸드트럭 배너 조회 API 추가: ID, 이미지 URL, 제목을 포함한 배너 목록을 사전 정의된 순서로 반환합니다.
  * 배너 응답 포맷이 표준화되어 클라이언트에서 일관되게 처리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->