### PR TITLE
Feat: 푸드트럭 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckBannerController.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/food-trucks/banners")
+@RequestMapping("/api/food-trucks/banners")
 public class FoodTruckBannerController implements FoodTruckBannerControllerDocs {
 
     private final FoodTruckBannerService foodTruckBannerService;

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
@@ -1,0 +1,34 @@
+package com.ds.dsfest.domain.foodtruck.controller;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
+import com.ds.dsfest.domain.foodtruck.service.FoodTruckService;
+import com.ds.dsfest.global.response.ApiResponse; // ⬅️ 완벽하게 찾아낸 올바른 경로!
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 푸드트럭 API 컨트롤러 구현체
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/food-trucks")
+public class FoodTruckController implements FoodTruckControllerDocs {
+
+    private final FoodTruckService foodTruckService;
+
+    /**
+     * 배너 목록 조회 API
+     */
+    @GetMapping
+    @Override
+    public ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList() {
+        List<FoodTruckListResDto> result = foodTruckService.getFoodTruckList();
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
@@ -2,7 +2,7 @@ package com.ds.dsfest.domain.foodtruck.controller;
 
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.domain.foodtruck.service.FoodTruckService;
-import com.ds.dsfest.global.response.ApiResponse; // ⬅️ 완벽하게 찾아낸 올바른 경로!
+import com.ds.dsfest.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +22,7 @@ public class FoodTruckController implements FoodTruckControllerDocs {
     private final FoodTruckService foodTruckService;
 
     /**
-     * 배너 목록 조회 API
+     * 푸드트럭 목록 조회 API
      */
     @GetMapping
     @Override

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/food-trucks")
+@RequestMapping("/api/food-trucks")
 public class FoodTruckController implements FoodTruckControllerDocs {
 
     private final FoodTruckService foodTruckService;

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
@@ -1,0 +1,22 @@
+package com.ds.dsfest.domain.foodtruck.controller;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+/**
+ * 푸드트럭 관련 API Swagger 문서화 인터페이스
+ */
+@Tag(name = "FoodTruck", description = "푸드트럭 관련 API")
+public interface FoodTruckControllerDocs {
+
+    /**
+     * 푸드트럭 목록 조회 API
+     */
+    @Operation(summary = "푸드트럭 리스트 조회", description = "푸드트럭 메인 탭에 표시될 트럭 목록을 조회합니다.")
+    ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList();
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckListResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckListResDto.java
@@ -1,0 +1,35 @@
+package com.ds.dsfest.domain.foodtruck.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 푸드트럭 리스트 조회를 위한 응답 DTO
+ */
+@Schema(description = "푸드트럭 리스트 응답 데이터")
+public record FoodTruckListResDto(
+
+    @Schema(description = "푸드트럭 고유 식별자", example = "1")
+    Long id,
+
+    @Schema(description = "푸드트럭 썸네일 이미지 URL", example = "https://dsfest.s3.ap-northeast-2.amazonaws.com/food-trucks/creamy.jpg")
+    String imageUrl,
+
+    @Schema(description = "푸드트럭 이름", example = "크래미 분식집")
+    String name,
+
+    @Schema(description = "대표 메뉴 이름 (태그 하단 표시용)", example = "크래미 김밥")
+    String representativeMenu,
+
+    @Schema(description = "푸드트럭 태그 (해시태그 형태)", example = "#간편식 #고기/BBQ")
+    String description,
+
+    @Schema(description = "운영 날짜 및 시간 요약 (오늘 날짜 기준)", example = "13일(수) 13:00 - 20:00")
+    String operatingDays,
+
+    @Schema(description = "맛있어요(좋아요) 누적 개수", example = "999")
+    Integer likeCount,
+
+    @Schema(description = "현재 운영 중 여부 (true: 운영 중, false: 영업 종료/휴무)", example = "true")
+    Boolean isOpen
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckMapper.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckMapper.java
@@ -1,0 +1,33 @@
+package com.ds.dsfest.domain.foodtruck.mapper;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import org.springframework.stereotype.Component;
+
+/**
+ * 푸드트럭 엔티티와 DTO 간의 변환을 담당하는 매퍼
+ */
+@Component
+public class FoodTruckMapper {
+
+    /**
+     * FoodTruck 엔티티를 FoodTruckListResDto로 변환합니다.
+     *
+     * @param foodTruck     푸드트럭 엔티티
+     * @param operatingDays 운영 시간 문자열
+     * @param likeCount     좋아요 개수
+     * @return 푸드트럭 리스트 응답 DTO
+     */
+    public FoodTruckListResDto toFoodTruckListResDto(FoodTruck foodTruck, String operatingDays, Integer likeCount, Boolean isOpen) {
+        return new FoodTruckListResDto(
+            foodTruck.getId(),
+            foodTruck.getImageUrl(),
+            foodTruck.getName(),
+            foodTruck.getRepresentativeMenu(),
+            foodTruck.getDescription(),
+            operatingDays,
+            likeCount,
+            isOpen
+        );
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckRepository.java
@@ -1,0 +1,21 @@
+package com.ds.dsfest.domain.foodtruck.repository;
+
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 푸드트럭 엔티티에 접근하기 위한 레포지토리 인터페이스
+ */
+@Repository
+public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long> {
+
+    /**
+     * 모든 푸드트럭 목록을 조회합니다.
+     */
+    @Query("SELECT f FROM FoodTruck f")
+    List<FoodTruck> findAllFoodTrucks();
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckRepository.java
@@ -14,8 +14,8 @@ import java.util.List;
 public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long> {
 
     /**
-     * 모든 푸드트럭 목록을 조회합니다.
+     * 푸드트럭과 운영 일정(operatingDays)을 한 번의 쿼리로 함께 조회합니다.
      */
-    @Query("SELECT f FROM FoodTruck f")
-    List<FoodTruck> findAllFoodTrucks();
+    @Query("SELECT DISTINCT f FROM FoodTruck f JOIN FETCH f.operatingDays")
+    List<FoodTruck> findAllWithOperatingDays();
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.time.Clock;
 
 /**
  * 푸드트럭 도메인의 비즈니스 로직을 담당하는 서비스 클래스입니다.
@@ -31,6 +32,7 @@ public class FoodTruckService {
 
     private final FoodTruckRepository foodTruckRepository;
     private final FoodTruckMapper foodTruckMapper;
+    private final Clock clock;
 
     /**
      * 현재 서버 시간과 DB의 운영 일차(festivalDay) 정보를 비교하여 푸드트럭 목록을 조회합니다.
@@ -41,7 +43,7 @@ public class FoodTruckService {
     public List<FoodTruckListResDto> getFoodTruckList() {
         List<FoodTruck> foodTrucks = foodTruckRepository.findAllWithOperatingDays();
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
         LocalDate today = now.toLocalDate();
         LocalTime currentTime = now.toLocalTime();
 
@@ -97,7 +99,7 @@ public class FoodTruckService {
      * @return 축제 일차 (1, 2, 3), 축제 기간이 아닐 경우 -1 반환
      */
     private int getFestivalDayFromDate(LocalDate date) {
-        if (date.equals(LocalDate.of(2026, 5, 13))) return 1;
+        if (date.equals(LocalDate.of(2026, 4, 24))) return 1;
         if (date.equals(LocalDate.of(2026, 5, 14))) return 2;
         if (date.equals(LocalDate.of(2026, 5, 15))) return 3;
 

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -6,24 +6,25 @@ import com.ds.dsfest.domain.foodtruck.entity.FoodTruckOperatingDay;
 import com.ds.dsfest.domain.foodtruck.mapper.FoodTruckMapper;
 import com.ds.dsfest.domain.foodtruck.repository.FoodTruckRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.time.Clock;
 
 /**
  * 푸드트럭 도메인의 비즈니스 로직을 담당하는 서비스 클래스입니다.
- * 푸드트럭 목록 조회 및 운영 상태(isOpen) 판별 등의 기능을 제공합니다.
  */
 @Service
 @RequiredArgsConstructor
@@ -35,10 +36,13 @@ public class FoodTruckService {
     private final Clock clock;
 
     /**
-     * 현재 서버 시간과 DB의 운영 일차(festivalDay) 정보를 비교하여 푸드트럭 목록을 조회합니다.
-     * 프론트엔드의 새로고침 버튼 대응 및 트럭 간 노출 형평성을 위해 조회된 리스트는 무작위로 섞어서 반환합니다.
-     *
-     * @return 운영 상태 및 오늘 일정이 포함된 푸드트럭 리스트 응답 DTO 목록
+     * application.yml의 festival.start-date 값을 가져옵니다.
+     */
+    @Value("${festival.start-date}")
+    private String festivalStartDateStr;
+
+    /**
+     * 현재 서버 시간과 DB의 운영 일차 정보를 비교하여 푸드트럭 목록을 조회합니다.
      */
     public List<FoodTruckListResDto> getFoodTruckList() {
         List<FoodTruck> foodTrucks = foodTruckRepository.findAllWithOperatingDays();
@@ -49,12 +53,12 @@ public class FoodTruckService {
 
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
-        int currentFestivalDay = getFestivalDayFromDate(today); // 오늘이 축제 몇 일차인지 계산 (축제 기간 아니면 -1 반환)
+        int currentFestivalDay = getFestivalDayFromDate(today); // 오늘 축제 몇 일차인지 계산
 
         List<FoodTruckListResDto> resultList = foodTrucks.stream()
             .map(truck -> {
                 /**
-                 * 운영 리스트 중 '오늘(currentFestivalDay)'에 해당하는 일정 찾기
+                 * 엔티티의 festivalDay 필드를 사용하여 오늘 일정 필터링
                  */
                 Optional<FoodTruckOperatingDay> todaySchedule = truck.getOperatingDays().stream()
                     .filter(schedule -> schedule.getFestivalDay() == currentFestivalDay)
@@ -63,14 +67,14 @@ public class FoodTruckService {
                 boolean isOpen = false;
                 String operatingDaysString = "운영 정보 없음";
 
-                /**
-                 * 오늘 영업하는 트럭일 경우
-                 */
                 if (todaySchedule.isPresent()) {
                     FoodTruckOperatingDay schedule = todaySchedule.get();
                     LocalTime start = schedule.getStartTime();
                     LocalTime end = schedule.getEndTime();
 
+                    /**
+                     * 피그마 양식에 맞게 문자열 조립
+                     */
                     String dayOfWeek = today.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
                     operatingDaysString = String.format("%d일(%s) %s - %s",
                         today.getDayOfMonth(),
@@ -78,31 +82,31 @@ public class FoodTruckService {
                         start.format(timeFormatter),
                         end.format(timeFormatter));
 
-                    isOpen = !currentTime.isBefore(start) && !currentTime.isAfter(end); // 현재 시간과 비교하여 영업 여부(isOpen) 결정
+                    isOpen = !currentTime.isBefore(start) && currentTime.isBefore(end); // 영업 여부 판별
                 }
 
-                Integer dummyLikeCount = 999; // 좋아요 구현 예정
+                Integer dummyLikeCount = 999;
 
                 return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, dummyLikeCount, isOpen);
             })
             .collect(Collectors.toList());
 
-        Collections.shuffle(resultList); // 새로고침 시 형평성 보장 위해 리스트 순서 랜덤하게 섞음
+        Collections.shuffle(resultList);
 
         return resultList;
     }
 
     /**
-     * 실제 날짜(LocalDate)를 축제 일차(festivalDay: 1, 2, 3) 엔티티 구조로 변환합니다.
-     *
-     * @param date 변환할 기준 날짜 (주로 서버의 현재 날짜)
-     * @return 축제 일차 (1, 2, 3), 축제 기간이 아닐 경우 -1 반환
+     * 날짜를 기반으로 축제 일차를 계산합니다.
      */
     private int getFestivalDayFromDate(LocalDate date) {
-        if (date.equals(LocalDate.of(2026, 4, 24))) return 1;
-        if (date.equals(LocalDate.of(2026, 5, 14))) return 2;
-        if (date.equals(LocalDate.of(2026, 5, 15))) return 3;
+        LocalDate startDate = LocalDate.parse(festivalStartDateStr);
+        long diff = ChronoUnit.DAYS.between(startDate, date);
+        int festivalDay = (int) diff + 1;
 
+        if (festivalDay >= 1 && festivalDay <= 3) {
+            return festivalDay;
+        }
         return -1;
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -1,0 +1,106 @@
+package com.ds.dsfest.domain.foodtruck.service;
+
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckOperatingDay;
+import com.ds.dsfest.domain.foodtruck.mapper.FoodTruckMapper;
+import com.ds.dsfest.domain.foodtruck.repository.FoodTruckRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 푸드트럭 도메인의 비즈니스 로직을 담당하는 서비스 클래스입니다.
+ * 푸드트럭 목록 조회 및 운영 상태(isOpen) 판별 등의 기능을 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FoodTruckService {
+
+    private final FoodTruckRepository foodTruckRepository;
+    private final FoodTruckMapper foodTruckMapper;
+
+    /**
+     * 현재 서버 시간과 DB의 운영 일차(festivalDay) 정보를 비교하여 푸드트럭 목록을 조회합니다.
+     * 프론트엔드의 새로고침 버튼 대응 및 트럭 간 노출 형평성을 위해 조회된 리스트는 무작위로 섞어서 반환합니다.
+     *
+     * @return 운영 상태 및 오늘 일정이 포함된 푸드트럭 리스트 응답 DTO 목록
+     */
+    public List<FoodTruckListResDto> getFoodTruckList() {
+        List<FoodTruck> foodTrucks = foodTruckRepository.findAll();
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = now.toLocalDate();
+        LocalTime currentTime = now.toLocalTime();
+
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        int currentFestivalDay = getFestivalDayFromDate(today); // 오늘이 축제 몇 일차인지 계산 (축제 기간 아니면 -1 반환)
+
+        List<FoodTruckListResDto> resultList = foodTrucks.stream()
+            .map(truck -> {
+                /**
+                 * 운영 리스트 중 '오늘(currentFestivalDay)'에 해당하는 일정 찾기
+                 */
+                Optional<FoodTruckOperatingDay> todaySchedule = truck.getOperatingDays().stream()
+                    .filter(schedule -> schedule.getFestivalDay() == currentFestivalDay)
+                    .findFirst();
+
+                boolean isOpen = false;
+                String operatingDaysString = "운영 정보 없음";
+
+                /**
+                 * 오늘 영업하는 트럭일 경우
+                 */
+                if (todaySchedule.isPresent()) {
+                    FoodTruckOperatingDay schedule = todaySchedule.get();
+                    LocalTime start = schedule.getStartTime();
+                    LocalTime end = schedule.getEndTime();
+
+                    String dayOfWeek = today.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+                    operatingDaysString = String.format("%d일(%s) %s - %s",
+                        today.getDayOfMonth(),
+                        dayOfWeek,
+                        start.format(timeFormatter),
+                        end.format(timeFormatter));
+
+                    isOpen = !currentTime.isBefore(start) && !currentTime.isAfter(end); // 현재 시간과 비교하여 영업 여부(isOpen) 결정
+                }
+
+                Integer dummyLikeCount = 999; // 좋아요 구현 예정
+
+                return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, dummyLikeCount, isOpen);
+            })
+            .collect(Collectors.toList());
+
+        Collections.shuffle(resultList); // 새로고침 시 형평성 보장 위해 리스트 순서 랜덤하게 섞음
+
+        return resultList;
+    }
+
+    /**
+     * 실제 날짜(LocalDate)를 축제 일차(festivalDay: 1, 2, 3) 엔티티 구조로 변환합니다.
+     *
+     * @param date 변환할 기준 날짜 (주로 서버의 현재 날짜)
+     * @return 축제 일차 (1, 2, 3), 축제 기간이 아닐 경우 -1 반환
+     */
+    private int getFestivalDayFromDate(LocalDate date) {
+        if (date.equals(LocalDate.of(2026, 5, 13))) return 1;
+        if (date.equals(LocalDate.of(2026, 5, 14))) return 2;
+        if (date.equals(LocalDate.of(2026, 5, 15))) return 3;
+
+        return -1;
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -39,7 +39,7 @@ public class FoodTruckService {
      * @return 운영 상태 및 오늘 일정이 포함된 푸드트럭 리스트 응답 DTO 목록
      */
     public List<FoodTruckListResDto> getFoodTruckList() {
-        List<FoodTruck> foodTrucks = foodTruckRepository.findAll();
+        List<FoodTruck> foodTrucks = foodTruckRepository.findAllWithOperatingDays();
 
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();


### PR DESCRIPTION
- 푸드트럭 메인 탭에 표시될 전체 트럭 목록 조회 기능 추가
- 서버 현재 시간을 기준으로 트럭별 당일 운영 상태 판별 로직 적용
- 트럭 노출 목록 무작위 정렬 기능 추가

## #️⃣ 연관된 이슈
- close #36 

## 📝 작업 내용
- **리스트 조회 API 구현:** `FoodTruckController`, `FoodTruckService`, `FoodTruckListResDto` 세팅
- **동적 운영 상태(`isOpen`) 계산:** - `FoodTruckOperatingDay` 엔티티의 `festivalDay`와 서버의 현재 날짜를 매핑하여 당일 일정 필터링
  - 현재 서버 시간과 `startTime`, `endTime`을 비교하여 `isOpen` 필드 `true/false` 동적 반환
- **목록 셔플(Shuffle) 적용:** 특정 트럭만 상단에 고정되는 형평성 문제를 해결하고 프론트엔드의 새로고침 버튼에 대응하기 위해 `Collections.shuffle()` 적용

## 📌 API 목록
- `GET /api/v1/food-trucks`

## 💬 리뷰 요구사항 혹은 참고 사항
- **프론트엔드 필터링:** 리스트 응답 값에 `isOpen` 필드가 포함되어 있습니다. '운영 중' 탭 클릭 시 서버에서 내려주는 이 값이 `true`인 데이터만 필터링해서 보여주시면 됩니다.
- **태그 정보:** 카드에 들어가는 `#간편식 #고기/BBQ` 등의 태그 정보는 `description` 필드에 띄어쓰기로 구분된 String 형태로 내려갑니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 푸드트럭 목록 조회 API 추가 — ID, 이미지, 이름, 대표메뉴, 태그형 설명, 요약된 운영일, 당일 운영시간, 좋아요 수 및 실시간 운영 여부 제공. 목록은 매번 섞여서 반환됩니다.
* **문서**
  * 푸드트럭 API용 OpenAPI/Swagger 문서 추가로 엔드포인트와 응답 형식 확인 가능.
* **기타**
  * 일부 푸드트럭 배너 엔드포인트의 기본 경로에서 버전 세그먼트가 제거되어 경로가 변경됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->