### PR TITLE
Feat: 라이브톡- 읽지 않은 메시지 수

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -3,9 +3,7 @@ package com.ds.dsfest.domain.livetalk.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.ds.dsfest.domain.livetalk.dto.ChatMessageResDto;
 import com.ds.dsfest.domain.livetalk.service.LiveTalkService;
@@ -20,8 +18,22 @@ public class LiveTalkController {
 
   private final LiveTalkService liveTalkService;
 
+  // 메시지 목록
   @GetMapping("/messages")
   public ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getRecentMessages() {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getRecentMessages()));
+  }
+
+  // 읽음 처리
+  @PatchMapping("/read")
+  public ResponseEntity<ApiResponse<Void>> markAsRead(@RequestParam String guestUuid) {
+    liveTalkService.markAsRead(guestUuid);
+    return ResponseEntity.ok(ApiResponse.onSuccess(null));
+  }
+
+  // 안 읽은 메시지 수
+  @GetMapping("/unread-count")
+  public ResponseEntity<ApiResponse<Long>> getUnreadCount(@RequestParam String guestUuid) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getUnreadCount(guestUuid)));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkMessageController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkMessageController.java
@@ -1,6 +1,7 @@
 package com.ds.dsfest.domain.livetalk.controller;
 
 import jakarta.validation.Valid;
+
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;

--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkMessageController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkMessageController.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.livetalk.controller;
 
+import jakarta.validation.Valid;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,7 +20,7 @@ public class LiveTalkMessageController {
   private final SimpMessagingTemplate messagingTemplate;
 
   @MessageMapping("/livetalk.send")
-  public void sendMessage(@Payload ChatMessageSendReqDto request) {
+  public void sendMessage(@Valid @Payload ChatMessageSendReqDto request) {
     ChatMessageResDto response =
         liveTalkService.saveMessage(request.guestUuid(), request.content());
 

--- a/src/main/java/com/ds/dsfest/domain/livetalk/entity/ChatReadStatus.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/entity/ChatReadStatus.java
@@ -1,0 +1,40 @@
+package com.ds.dsfest.domain.livetalk.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_read_status")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatReadStatus {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String guestUuid;
+
+  @Column(nullable = false)
+  private LocalDateTime lastReadAt;
+
+  public ChatReadStatus(String guestUuid, LocalDateTime lastReadAt) {
+    this.guestUuid = guestUuid;
+    this.lastReadAt = lastReadAt;
+  }
+
+  public void updateLastReadAt(LocalDateTime lastReadAt) {
+    this.lastReadAt = lastReadAt;
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
@@ -1,6 +1,8 @@
 package com.ds.dsfest.domain.livetalk.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +11,8 @@ import com.ds.dsfest.domain.livetalk.entity.ChatMessage;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
   List<ChatMessage> findTop50ByOrderByCreatedAtDesc();
+
+  long countByCreatedAtAfterAndGuestUser_UuidNot(LocalDateTime lastReadAt, UUID guestUuid);
+
+  long countByGuestUser_UuidNot(UUID guestUuid);
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
@@ -1,0 +1,12 @@
+package com.ds.dsfest.domain.livetalk.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
+
+public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, Long> {
+
+  Optional<ChatReadStatus> findByGuestUuid(String guestUuid);
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.livetalk.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -8,8 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ds.dsfest.domain.livetalk.dto.ChatMessageResDto;
 import com.ds.dsfest.domain.livetalk.entity.ChatMessage;
+import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
 import com.ds.dsfest.domain.livetalk.mapper.ChatMessageMapper;
 import com.ds.dsfest.domain.livetalk.repository.ChatMessageRepository;
+import com.ds.dsfest.domain.livetalk.repository.ChatReadStatusRepository;
 import com.ds.dsfest.domain.user.entity.GuestUser;
 import com.ds.dsfest.domain.user.exception.UserErrorCode;
 import com.ds.dsfest.domain.user.repository.GuestUserRepository;
@@ -25,6 +28,7 @@ public class LiveTalkService {
   private final ChatMessageRepository chatMessageRepository;
   private final GuestUserRepository guestUserRepository;
   private final ChatMessageMapper chatMessageMapper;
+  private final ChatReadStatusRepository chatReadStatusRepository;
 
   @Transactional(readOnly = true)
   public List<ChatMessageResDto> getRecentMessages() {
@@ -44,13 +48,13 @@ public class LiveTalkService {
             .findById(uuid)
             .orElseThrow(() -> new CustomException(UserErrorCode.GUEST_NOT_FOUND));
 
-      String normalizedContent = content == null ? "" : content.trim();
-      if (normalizedContent.isBlank()) {
-          throw new IllegalArgumentException("메시지는 비어 있을 수 없습니다.");
-      }
-      if (normalizedContent.length() > 500) {
-          throw new IllegalArgumentException("메시지는 500자를 초과할 수 없습니다.");
-      }
+    String normalizedContent = content == null ? "" : content.trim();
+    if (normalizedContent.isBlank()) {
+      throw new IllegalArgumentException("메시지는 비어 있을 수 없습니다.");
+    }
+    if (normalizedContent.length() > 500) {
+      throw new IllegalArgumentException("메시지는 500자를 초과할 수 없습니다.");
+    }
 
     ChatMessage chatMessage = ChatMessage.create(guestUser, normalizedContent);
     ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
@@ -59,13 +63,44 @@ public class LiveTalkService {
   }
 
   private UUID parseUuid(String guestUuid) {
-      if (guestUuid == null || guestUuid.isBlank()) {
-          throw new IllegalArgumentException("guestUuid는 필수값입니다.");
-      }
-      try {
-        return UUID.fromString(guestUuid.trim());
-      } catch (IllegalArgumentException e) {
-          throw new IllegalArgumentException("올바르지 않은 guestUuid 형식입니다.");
-      }
+    if (guestUuid == null || guestUuid.isBlank()) {
+      throw new IllegalArgumentException("guestUuid는 필수값입니다.");
+    }
+    try {
+      return UUID.fromString(guestUuid.trim());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("올바르지 않은 guestUuid 형식입니다.");
+    }
+  }
+
+  // ✅ 읽음 처리
+  @Transactional
+  public void markAsRead(String guestUuid) {
+    parseUuid(guestUuid); // 유효성 체크
+
+    LocalDateTime now = LocalDateTime.now();
+
+    ChatReadStatus status =
+        chatReadStatusRepository
+            .findByGuestUuid(guestUuid)
+            .orElseGet(() -> new ChatReadStatus(guestUuid, now));
+
+    status.updateLastReadAt(now);
+
+    chatReadStatusRepository.save(status);
+  }
+
+  // ✅ 안 읽은 메시지 수
+  @Transactional(readOnly = true)
+  public long getUnreadCount(String guestUuid) {
+    UUID uuid = parseUuid(guestUuid);
+
+    return chatReadStatusRepository
+        .findByGuestUuid(guestUuid)
+        .map(
+            status ->
+                chatMessageRepository.countByCreatedAtAfterAndGuestUser_UuidNot(
+                    status.getLastReadAt(), uuid))
+        .orElseGet(() -> chatMessageRepository.countByGuestUser_UuidNot(uuid));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -44,10 +44,13 @@ public class LiveTalkService {
             .findById(uuid)
             .orElseThrow(() -> new CustomException(UserErrorCode.GUEST_NOT_FOUND));
 
-    String normalizedContent = content == null ? "" : content.trim();
-    if (normalizedContent.isBlank()) {
-      throw new IllegalArgumentException("메시지는 비어 있을 수 없습니다.");
-    }
+      String normalizedContent = content == null ? "" : content.trim();
+      if (normalizedContent.isBlank()) {
+          throw new IllegalArgumentException("메시지는 비어 있을 수 없습니다.");
+      }
+      if (normalizedContent.length() > 500) {
+          throw new IllegalArgumentException("메시지는 500자를 초과할 수 없습니다.");
+      }
 
     ChatMessage chatMessage = ChatMessage.create(guestUser, normalizedContent);
     ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
@@ -56,10 +59,13 @@ public class LiveTalkService {
   }
 
   private UUID parseUuid(String guestUuid) {
-    try {
-      return UUID.fromString(guestUuid);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("올바르지 않은 guestUuid 형식입니다.");
-    }
+      if (guestUuid == null || guestUuid.isBlank()) {
+          throw new IllegalArgumentException("guestUuid는 필수값입니다.");
+      }
+      try {
+        return UUID.fromString(guestUuid.trim());
+      } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("올바르지 않은 guestUuid 형식입니다.");
+      }
   }
 }

--- a/src/main/java/com/ds/dsfest/global/config/CorsConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/CorsConfig.java
@@ -20,7 +20,13 @@ public class CorsConfig {
             "http://localhost:5173",
             "http://localhost:5500",
             "http://127.0.0.1:5500"));
-    config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173", "https://api.youth-of-duksung.site", "https://youth-of-duksung.site", "https://www.youth-of-duksung.site"));
+    config.setAllowedOrigins(
+        List.of(
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "https://api.youth-of-duksung.site",
+            "https://youth-of-duksung.site",
+            "https://www.youth-of-duksung.site"));
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     config.setAllowedHeaders(List.of("*"));
     config.setAllowCredentials(true);

--- a/src/main/java/com/ds/dsfest/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/WebSocketConfig.java
@@ -21,6 +21,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     // WebSocket 연결 엔드포인트 (SockJS 폴백 포함)
-    registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) close #37 

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
guestUuid 로 구분. 읽기전엔 unread-count 에 메시지수 뜨고, 읽으면 0 으로 바뀜 

### 스크린샷 (선택)

## 📌 API 목록
/api/livetalk/unread-count - 읽지 않은 메시지 수 세기
/api/livetalk/read - 읽음 처리

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 라이브톡 메시지 읽음 상태 추적 기능 추가
  * 미읽음 메시지 수 조회 기능 추가

* **개선 사항**
  * WebSocket 메시지 유효성 검사 강화
  * WebSocket 연결 호환성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->