### PR TITLE
Feat: 이전 메시지 조회

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -24,6 +24,13 @@ public class LiveTalkController {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getRecentMessages()));
   }
 
+  // 이전 메시지
+  @GetMapping("/messages/before")
+  public ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getMessagesBefore(
+      @RequestParam Long messageId) {
+    return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getMessagesBefore(messageId)));
+  }
+
   // 읽음 처리
   @PatchMapping("/read")
   public ResponseEntity<ApiResponse<Void>> markAsRead(@RequestParam String guestUuid) {

--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -2,6 +2,8 @@ package com.ds.dsfest.domain.livetalk.controller;
 
 import java.util.List;
 
+import com.ds.dsfest.domain.livetalk.dto.ChatTopicResDto;
+import com.ds.dsfest.domain.livetalk.service.ChatTopicService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,4 +45,12 @@ public class LiveTalkController {
   public ResponseEntity<ApiResponse<Long>> getUnreadCount(@RequestParam String guestUuid) {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getUnreadCount(guestUuid)));
   }
+
+
+  private final ChatTopicService chatTopicService;
+// 대화 주제
+  @GetMapping("/topics/current")
+    public ChatTopicResDto getCurrentTopic() {
+        return chatTopicService.getCurrentTopic();
+    }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/dto/ChatTopicResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/dto/ChatTopicResDto.java
@@ -1,0 +1,17 @@
+package com.ds.dsfest.domain.livetalk.dto;
+
+import com.ds.dsfest.domain.livetalk.entity.ChatTopic;
+
+public record ChatTopicResDto(
+    Long id,
+    String content,
+    com.ds.dsfest.domain.livetalk.constant.ChatTopicType topicType,
+    Long artistId) {
+  public static ChatTopicResDto from(ChatTopic chatTopic) {
+    return new ChatTopicResDto(
+        chatTopic.getId(),
+        chatTopic.getContent(),
+        chatTopic.getTopicType(),
+        chatTopic.getArtist() != null ? chatTopic.getArtist().getId() : null);
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/entity/TopicType.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/entity/TopicType.java
@@ -1,0 +1,6 @@
+package com.ds.dsfest.domain.livetalk.entity;
+
+public enum TopicType {
+  GENERAL,
+  ARTIST
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
@@ -12,6 +12,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
   List<ChatMessage> findTop50ByOrderByCreatedAtDesc();
 
+  List<ChatMessage> findTop50ByIdLessThanOrderByIdDesc(Long messageId);
+
   long countByCreatedAtAfterAndGuestUser_UuidNot(LocalDateTime lastReadAt, UUID guestUuid);
 
   long countByGuestUser_UuidNot(UUID guestUuid);

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatMessageRepository.java
@@ -4,14 +4,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ds.dsfest.domain.livetalk.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
+  @EntityGraph(attributePaths = {"guestUser"})
   List<ChatMessage> findTop50ByOrderByCreatedAtDesc();
 
+  @EntityGraph(attributePaths = {"guestUser"})
   List<ChatMessage> findTop50ByIdLessThanOrderByIdDesc(Long messageId);
 
   long countByCreatedAtAfterAndGuestUser_UuidNot(LocalDateTime lastReadAt, UUID guestUuid);

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
@@ -1,12 +1,24 @@
 package com.ds.dsfest.domain.livetalk.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, Long> {
 
   Optional<ChatReadStatus> findByGuestUuid(String guestUuid);
+
+  @Modifying
+
+  @Query(value = """
+    INSERT INTO chat_read_status (guest_uuid, last_read_at)
+    VALUES (:guestUuid, :lastReadAt)
+    ON DUPLICATE KEY UPDATE last_read_at = VALUES(last_read_at)
+    """, nativeQuery = true)
+    void upsertReadStatus(String guestUuid, LocalDateTime lastReadAt);
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatReadStatusRepository.java
@@ -4,21 +4,25 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
 
 public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, Long> {
 
   Optional<ChatReadStatus> findByGuestUuid(String guestUuid);
 
-  @Modifying
-
-  @Query(value = """
+  @Modifying(clearAutomatically = true)
+  @Query(
+      value =
+          """
     INSERT INTO chat_read_status (guest_uuid, last_read_at)
     VALUES (:guestUuid, :lastReadAt)
     ON DUPLICATE KEY UPDATE last_read_at = VALUES(last_read_at)
-    """, nativeQuery = true)
-    void upsertReadStatus(String guestUuid, LocalDateTime lastReadAt);
+    """,
+      nativeQuery = true)
+  void upsertReadStatus(
+      @Param("guestUuid") String guestUuid, @Param("lastReadAt") LocalDateTime lastReadAt);
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatTopicRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/repository/ChatTopicRepository.java
@@ -1,0 +1,17 @@
+package com.ds.dsfest.domain.livetalk.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ds.dsfest.domain.livetalk.entity.ChatTopic;
+
+public interface ChatTopicRepository extends JpaRepository<ChatTopic, Long> {
+
+  @EntityGraph(attributePaths = {"artist"})
+  Optional<ChatTopic>
+      findFirstByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeDesc(
+          LocalDateTime now, LocalDateTime now2);
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/ChatTopicService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/ChatTopicService.java
@@ -1,0 +1,28 @@
+package com.ds.dsfest.domain.livetalk.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ds.dsfest.domain.livetalk.dto.ChatTopicResDto;
+import com.ds.dsfest.domain.livetalk.repository.ChatTopicRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatTopicService {
+
+  private final ChatTopicRepository chatTopicRepository;
+
+  public ChatTopicResDto getCurrentTopic() {
+    LocalDateTime now = LocalDateTime.now();
+
+    return chatTopicRepository
+        .findFirstByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeDesc(now, now)
+        .map(ChatTopicResDto::from)
+        .orElse(null);
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ds.dsfest.domain.livetalk.dto.ChatMessageResDto;
 import com.ds.dsfest.domain.livetalk.entity.ChatMessage;
-import com.ds.dsfest.domain.livetalk.entity.ChatReadStatus;
 import com.ds.dsfest.domain.livetalk.mapper.ChatMessageMapper;
 import com.ds.dsfest.domain.livetalk.repository.ChatMessageRepository;
 import com.ds.dsfest.domain.livetalk.repository.ChatReadStatusRepository;
@@ -32,9 +31,15 @@ public class LiveTalkService {
 
   @Transactional(readOnly = true)
   public List<ChatMessageResDto> getRecentMessages() {
-    List<ChatMessage> messages = chatMessageRepository.findTop50ByOrderByCreatedAtDesc();
+    return chatMessageRepository.findTop50ByOrderByCreatedAtDesc().stream()
+        .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
+        .map(chatMessageMapper::toResDto)
+        .toList();
+  }
 
-    return messages.stream()
+  @Transactional(readOnly = true)
+  public List<ChatMessageResDto> getMessagesBefore(Long messageId) {
+    return chatMessageRepository.findTop50ByIdLessThanOrderByIdDesc(messageId).stream()
         .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
         .map(chatMessageMapper::toResDto)
         .toList();
@@ -76,27 +81,22 @@ public class LiveTalkService {
   // ✅ 읽음 처리
   @Transactional
   public void markAsRead(String guestUuid) {
-    parseUuid(guestUuid); // 유효성 체크
+      String normalizedGuestUuid = parseUuid(guestUuid).toString();
 
-    LocalDateTime now = LocalDateTime.now();
-
-    ChatReadStatus status =
-        chatReadStatusRepository
-            .findByGuestUuid(guestUuid)
-            .orElseGet(() -> new ChatReadStatus(guestUuid, now));
-
-    status.updateLastReadAt(now);
-
-    chatReadStatusRepository.save(status);
+      chatReadStatusRepository.upsertReadStatus(
+          normalizedGuestUuid,
+          LocalDateTime.now()
+      );
   }
 
   // ✅ 안 읽은 메시지 수
   @Transactional(readOnly = true)
   public long getUnreadCount(String guestUuid) {
     UUID uuid = parseUuid(guestUuid);
+    String normalizedGuestUuid = uuid.toString();
 
     return chatReadStatusRepository
-        .findByGuestUuid(guestUuid)
+        .findByGuestUuid(normalizedGuestUuid)
         .map(
             status ->
                 chatMessageRepository.countByCreatedAtAfterAndGuestUser_UuidNot(

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -81,12 +81,9 @@ public class LiveTalkService {
   // ✅ 읽음 처리
   @Transactional
   public void markAsRead(String guestUuid) {
-      String normalizedGuestUuid = parseUuid(guestUuid).toString();
+    String normalizedGuestUuid = parseUuid(guestUuid).toString();
 
-      chatReadStatusRepository.upsertReadStatus(
-          normalizedGuestUuid,
-          LocalDateTime.now()
-      );
+    chatReadStatusRepository.upsertReadStatus(normalizedGuestUuid, LocalDateTime.now());
   }
 
   // ✅ 안 읽은 메시지 수


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) close #41  

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
이전 메시지 조회

### 스크린샷 (선택)

## 📌 API 목록
/api/livetalk/messages/before - 이전 메시지 조회

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- markAsRead를 upsert 방식으로 교체
- Sockjs 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이전 메시지 불러오기 기능 추가로 스크롤 시 과거 대화 이력(최대 50건)을 확인할 수 있습니다.
  * 현재 채팅 주제 조회 기능 추가로 진행 중인 토픽을 표시합니다.

* **Bug Fixes**
  * 메시지 읽음 상태 처리 로직 개선으로 읽음 표시가 더 일관되고 안정적으로 동기화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->