### PR TITLE
Feat: 푸드트럭 맛있어요(좋아요) 토글 기능 구현

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
@@ -1,15 +1,15 @@
 package com.ds.dsfest.domain.foodtruck.controller;
 
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.domain.foodtruck.service.FoodTruckService;
 import com.ds.dsfest.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * 푸드트럭 API 컨트롤러 구현체
@@ -20,7 +20,6 @@ import java.util.List;
 public class FoodTruckController implements FoodTruckControllerDocs {
 
     private final FoodTruckService foodTruckService;
-
     /**
      * 푸드트럭 목록 조회 API
      */
@@ -28,7 +27,19 @@ public class FoodTruckController implements FoodTruckControllerDocs {
     @Override
     public ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList() {
         List<FoodTruckListResDto> result = foodTruckService.getFoodTruckList();
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 
+    /**
+     * 특정 푸드트럭에 대한 '맛있어요(좋아요)' 토글
+     */
+    @PostMapping("/{foodTruckId}/likes")
+    @Override
+    public ResponseEntity<ApiResponse<FoodTruckLikeResDto>> toggleFoodTruckLike(
+        @PathVariable Long foodTruckId,
+        @RequestHeader("guest_uuid") UUID guestUuid
+    ) {
+        FoodTruckLikeResDto result = foodTruckService.toggleFoodTruckLike(foodTruckId, guestUuid);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
@@ -1,12 +1,18 @@
 package com.ds.dsfest.domain.foodtruck.controller;
 
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * 푸드트럭 관련 API Swagger 문서화 인터페이스
@@ -19,4 +25,14 @@ public interface FoodTruckControllerDocs {
      */
     @Operation(summary = "푸드트럭 리스트 조회", description = "푸드트럭 메인 탭에 표시될 트럭 목록을 조회합니다.")
     ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList();
+
+    /**
+     * 푸드트럭 맛있어요 토글 API
+     */
+    @Operation(summary = "푸드트럭 맛있어요 토글", description = "좋아요가 없으면 생성(isLiked: true), 이미 존재하면 삭제(isLiked: false)됩니다.")
+    @Parameter(name = "guest_uuid", description = "비회원 식별용 UUID (커스텀 헤더)", required = true, in = ParameterIn.HEADER)
+    ResponseEntity<ApiResponse<FoodTruckLikeResDto>> toggleFoodTruckLike(
+        @PathVariable Long foodTruckId,
+        @RequestHeader("guest_uuid") UUID guestUuid
+    );
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckLikeResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckLikeResDto.java
@@ -1,0 +1,15 @@
+package com.ds.dsfest.domain.foodtruck.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 푸드트럭 맛있어요(좋아요) 토글 상태 응답 DTO
+ */
+@Schema(description = "푸드트럭 좋아요 토글 응답 데이터")
+public record FoodTruckLikeResDto(
+
+    @Schema(description = "좋아요 최종 상태 (true: 추가됨, false: 취소됨)", example = "true")
+    boolean isLiked
+
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckLike.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckLike.java
@@ -1,23 +1,13 @@
 package com.ds.dsfest.domain.foodtruck.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-
 import com.ds.dsfest.domain.user.entity.GuestUser;
 import com.ds.dsfest.global.common.BaseEntity;
-
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckLikeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckLikeRepository.java
@@ -1,0 +1,18 @@
+package com.ds.dsfest.domain.foodtruck.repository;
+
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckLike;
+import com.ds.dsfest.domain.user.entity.GuestUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FoodTruckLikeRepository extends JpaRepository<FoodTruckLike, Long> {
+    /**
+     * 특정 유저와 트럭으로 좋아요 존재 여부 확인
+     */
+    Optional<FoodTruckLike> findByGuestUserAndFoodTruck(GuestUser guestUser, FoodTruck foodTruck);
+
+
+    long countByFoodTruck(FoodTruck foodTruck); // 특정 트럭의 총 좋아요 개수
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -1,10 +1,18 @@
 package com.ds.dsfest.domain.foodtruck.service;
 
+import com.ds.dsfest.domain.booth.exception.BoothErrorCode;
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckLike;
 import com.ds.dsfest.domain.foodtruck.entity.FoodTruckOperatingDay;
 import com.ds.dsfest.domain.foodtruck.mapper.FoodTruckMapper;
+import com.ds.dsfest.domain.foodtruck.repository.FoodTruckLikeRepository;
 import com.ds.dsfest.domain.foodtruck.repository.FoodTruckRepository;
+import com.ds.dsfest.domain.user.entity.GuestUser;
+import com.ds.dsfest.domain.user.exception.UserErrorCode;
+import com.ds.dsfest.domain.user.repository.GuestUserRepository;
+import com.ds.dsfest.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -17,14 +25,11 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * 푸드트럭 도메인의 비즈니스 로직을 담당하는 서비스 클래스입니다.
+ * 푸드트럭 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,17 +37,18 @@ import java.util.stream.Collectors;
 public class FoodTruckService {
 
     private final FoodTruckRepository foodTruckRepository;
+    private final FoodTruckLikeRepository foodTruckLikeRepository;
+    private final GuestUserRepository guestUserRepository;
     private final FoodTruckMapper foodTruckMapper;
     private final Clock clock;
 
-    /**
-     * application.yml의 festival.start-date 값을 가져옵니다.
-     */
     @Value("${festival.start-date}")
     private String festivalStartDateStr;
 
     /**
-     * 현재 서버 시간과 DB의 운영 일차 정보를 비교하여 푸드트럭 목록을 조회합니다.
+     * 푸드트럭 목록을 조회하며, 실제 DB에 저장된 좋아요 개수를 합산하여 반환합니다.
+     *
+     * @return 좋아요 개수가 포함된 푸드트럭 리스트 DTO 목록
      */
     public List<FoodTruckListResDto> getFoodTruckList() {
         List<FoodTruck> foodTrucks = foodTruckRepository.findAllWithOperatingDays();
@@ -50,16 +56,12 @@ public class FoodTruckService {
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDate today = now.toLocalDate();
         LocalTime currentTime = now.toLocalTime();
-
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
-        int currentFestivalDay = getFestivalDayFromDate(today); // 오늘 축제 몇 일차인지 계산
+        int currentFestivalDay = getFestivalDayFromDate(today);
 
         List<FoodTruckListResDto> resultList = foodTrucks.stream()
             .map(truck -> {
-                /**
-                 * 엔티티의 festivalDay 필드를 사용하여 오늘 일정 필터링
-                 */
                 Optional<FoodTruckOperatingDay> todaySchedule = truck.getOperatingDays().stream()
                     .filter(schedule -> schedule.getFestivalDay() == currentFestivalDay)
                     .findFirst();
@@ -72,9 +74,6 @@ public class FoodTruckService {
                     LocalTime start = schedule.getStartTime();
                     LocalTime end = schedule.getEndTime();
 
-                    /**
-                     * 피그마 양식에 맞게 문자열 조립
-                     */
                     String dayOfWeek = today.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
                     operatingDaysString = String.format("%d일(%s) %s - %s",
                         today.getDayOfMonth(),
@@ -82,12 +81,13 @@ public class FoodTruckService {
                         start.format(timeFormatter),
                         end.format(timeFormatter));
 
-                    isOpen = !currentTime.isBefore(start) && currentTime.isBefore(end); // 영업 여부 판별
+                    isOpen = !currentTime.isBefore(start) && currentTime.isBefore(end);
                 }
 
-                Integer dummyLikeCount = 999;
 
-                return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, dummyLikeCount, isOpen);
+                int likeCount = (int) foodTruckLikeRepository.countByFoodTruck(truck); // 해당 트럭의 좋아요 개수 조회
+
+                return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, likeCount, isOpen);
             })
             .collect(Collectors.toList());
 
@@ -97,7 +97,47 @@ public class FoodTruckService {
     }
 
     /**
+     * 특정 푸드트럭에 대한 좋아요 상태를 토글합니다.
+     *
+     * @return 좋아요 후의 최종 상태 (true: 추가됨, false: 취소됨)
+     */
+    @Transactional
+    public FoodTruckLikeResDto toggleFoodTruckLike(Long foodTruckId, UUID guestUuid) {
+        /**
+         * 1. 푸드트럭 존재 여부 확인
+         */
+        FoodTruck foodTruck = foodTruckRepository.findById(foodTruckId)
+            .orElseThrow(() -> new CustomException(BoothErrorCode.BOOTH_NOT_FOUND));
+
+        /**
+         * 2. 사용자(GuestUser) 존재 여부 확인
+         */
+        GuestUser guestUser = guestUserRepository.findById(guestUuid)
+            .orElseThrow(() -> new CustomException(UserErrorCode.GUEST_NOT_FOUND));
+
+        /**
+         * 3. 좋아요 토글 로직
+         */
+        Optional<FoodTruckLike> existingLike = foodTruckLikeRepository.findByGuestUserAndFoodTruck(guestUser, foodTruck);
+
+        if (existingLike.isPresent()) {
+            foodTruckLikeRepository.delete(existingLike.get());
+            return new FoodTruckLikeResDto(false);
+        } else {
+            FoodTruckLike newLike = FoodTruckLike.builder()
+                .guestUser(guestUser)
+                .foodTruck(foodTruck)
+                .build();
+            foodTruckLikeRepository.save(newLike);
+            return new FoodTruckLikeResDto(true);
+        }
+    }
+
+    /**
      * 날짜를 기반으로 축제 일차를 계산합니다.
+     *
+     * @param date 기준 날짜
+     * @return 축제 일차 (1~3), 기간 외일 경우 -1
      */
     private int getFestivalDayFromDate(LocalDate date) {
         LocalDate startDate = LocalDate.parse(festivalStartDateStr);

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -15,6 +15,7 @@ import com.ds.dsfest.domain.user.repository.GuestUserRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,7 +86,7 @@ public class FoodTruckService {
                 }
 
 
-                int likeCount = (int) foodTruckLikeRepository.countByFoodTruck(truck); // 해당 트럭의 좋아요 개수 조회
+                int likeCount = Math.toIntExact(foodTruckLikeRepository.countByFoodTruck(truck)); // 해당 트럭의 좋아요 개수 조회
 
                 return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, likeCount, isOpen);
             })
@@ -124,12 +125,25 @@ public class FoodTruckService {
             foodTruckLikeRepository.delete(existingLike.get());
             return new FoodTruckLikeResDto(false);
         } else {
-            FoodTruckLike newLike = FoodTruckLike.builder()
-                .guestUser(guestUser)
-                .foodTruck(foodTruck)
-                .build();
-            foodTruckLikeRepository.save(newLike);
-            return new FoodTruckLikeResDto(true);
+            try {
+                FoodTruckLike newLike = FoodTruckLike.builder()
+                    .guestUser(guestUser)
+                    .foodTruck(foodTruck)
+                    .build();
+                foodTruckLikeRepository.save(newLike);
+                return new FoodTruckLikeResDto(true);
+
+            } catch (DataIntegrityViolationException e) {
+                /**
+                 * 동시에 여러 번 눌러서 Unique 제약조건 충돌(500)이 발생한 경우
+                 */
+                FoodTruckLike concurrentLike = foodTruckLikeRepository
+                    .findByGuestUserAndFoodTruck(guestUser, foodTruck)
+                    .orElseThrow(() -> e); // 만약 못 찾는다면 원래의 에러를 던집니다.
+
+                foodTruckLikeRepository.delete(concurrentLike);
+                return new FoodTruckLikeResDto(false);
+            }
         }
     }
 

--- a/src/main/java/com/ds/dsfest/domain/user/repository/GuestUserRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/user/repository/GuestUserRepository.java
@@ -1,9 +1,11 @@
 package com.ds.dsfest.domain.user.repository;
 
-import java.util.UUID;
-
+import com.ds.dsfest.domain.user.entity.GuestUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.ds.dsfest.domain.user.entity.GuestUser;
+import java.util.Optional;
+import java.util.UUID;
 
-public interface GuestUserRepository extends JpaRepository<GuestUser, UUID> {}
+public interface GuestUserRepository extends JpaRepository<GuestUser, UUID> {
+    Optional<GuestUser> findById(UUID uuid);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #39 

## 📝 작업 내용
- 좋아요 토글 기능 구현: FoodTruckLike 엔티티와 연동하여, 이미 좋아요를 누른 상태면 삭제(취소), 없으면 생성(추가)되는 로직을 구현했습니다.
- 비회원 식별 로직: 헤더의 guest_uuid를 통해 GuestUser를 식별하며, 잘못된 UUID 형식이나 존재하지 않는 유저에 대한 예외 처리를 완료했습니다.
- 데이터 동기화: 기존 푸드트럭 리스트 조회 API에서 좋아요 개수를 더미값(999) 대신 DB의 실제 카운트 값으로 반환하도록 수정했습니다.


## 📌 API 목록
`POST /api/food-trucks/{foodTruckId}/likes`

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- BoothErrorCode.BOOTH_NOT_FOUND: 존재하지 않는 푸드트럭 ID로 요청 시 발생
- UserErrorCode.GUEST_NOT_FOUND: 존재하지 않는 UUID로 요청 시 발생
- **UUID 형식 오류**: 헤더 형식이 올바르지 않을 경우 스프링 레벨에서 400 Bad Request 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* **푸드트럭 좋아요 기능**: 사용자가 관심 있는 푸드트럭을 좋아요로 표시할 수 있으며, 언제든지 좋아요를 해제할 수 있습니다
* **정확한 좋아요 개수 표시**: 각 푸드트럭의 좋아요 개수가 실제 사용자 데이터를 기반으로 정확하게 계산되어 표시됩니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->