### PR TITLE
Feat: 푸드트럭 상세 조회

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckController.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.foodtruck.controller;
 
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckDetailResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.domain.foodtruck.service.FoodTruckService;
@@ -25,8 +26,8 @@ public class FoodTruckController implements FoodTruckControllerDocs {
      */
     @GetMapping
     @Override
-    public ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList() {
-        List<FoodTruckListResDto> result = foodTruckService.getFoodTruckList();
+    public ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList(@RequestParam(value = "is-vegan", required = false, defaultValue = "false") boolean isVegan) {
+        List<FoodTruckListResDto> result = foodTruckService.getFoodTruckList(isVegan);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
@@ -40,6 +41,19 @@ public class FoodTruckController implements FoodTruckControllerDocs {
         @RequestHeader("guest_uuid") UUID guestUuid
     ) {
         FoodTruckLikeResDto result = foodTruckService.toggleFoodTruckLike(foodTruckId, guestUuid);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    /**
+     * 푸드트럭 상세 조회 API
+     */
+    @GetMapping("/{foodTruckId}")
+    @Override
+    public ResponseEntity<ApiResponse<FoodTruckDetailResDto>> getFoodTruckDetail(
+        @PathVariable Long foodTruckId,
+        @RequestHeader(value = "guest_uuid", required = false) UUID guestUuid
+    ) {
+        FoodTruckDetailResDto result = foodTruckService.getFoodTruckDetail(foodTruckId, guestUuid);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/controller/FoodTruckControllerDocs.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.foodtruck.controller;
 
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckDetailResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
 import com.ds.dsfest.global.response.ApiResponse;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 import java.util.UUID;
@@ -23,8 +25,11 @@ public interface FoodTruckControllerDocs {
     /**
      * 푸드트럭 목록 조회 API
      */
-    @Operation(summary = "푸드트럭 리스트 조회", description = "푸드트럭 메인 탭에 표시될 트럭 목록을 조회합니다.")
-    ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList();
+    @Operation(summary = "푸드트럭 리스트 조회", description = "푸드트럭 메인 탭에 표시될 트럭 목록을 조회합니다. 비건 필터를 적용할 수 있습니다.")
+    @Parameter(name = "is-vegan", description = "비건 메뉴 포함 트럭만 필터링 여부 (기본값: false)", required = false, in = ParameterIn.QUERY)
+    ResponseEntity<ApiResponse<List<FoodTruckListResDto>>> getFoodTruckList(
+        @RequestParam(value = "is-vegan", required = false, defaultValue = "false") boolean isVegan
+    );
 
     /**
      * 푸드트럭 맛있어요 토글 API
@@ -34,5 +39,15 @@ public interface FoodTruckControllerDocs {
     ResponseEntity<ApiResponse<FoodTruckLikeResDto>> toggleFoodTruckLike(
         @PathVariable Long foodTruckId,
         @RequestHeader("guest_uuid") UUID guestUuid
+    );
+
+    /**
+     * 푸드트럭 상세 조회 API
+     */
+    @Operation(summary = "푸드트럭 상세 조회", description = "특정 푸드트럭의 메뉴, 이미지 목록, 운영 시간 및 좋아요 여부 등 상세 정보를 조회합니다.")
+    @Parameter(name = "guest_uuid", description = "비회원 식별용 UUID (현재 사용자의 좋아요 여부 판별용. 필수는 아님)", required = false, in = ParameterIn.HEADER)
+    ResponseEntity<ApiResponse<FoodTruckDetailResDto>> getFoodTruckDetail(
+        @Parameter(description = "조회할 푸드트럭의 고유 ID", required = true) @PathVariable Long foodTruckId,
+        @RequestHeader(value = "guest_uuid", required = false) UUID guestUuid
     );
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckDetailResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckDetailResDto.java
@@ -1,0 +1,32 @@
+package com.ds.dsfest.domain.foodtruck.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "푸드트럭 상세 조회 응답 데이터")
+public record FoodTruckDetailResDto(
+    @Schema(description = "푸드트럭 고유 식별자", example = "1")
+    Long id,
+
+    @Schema(description = "푸드트럭 이미지 URL")
+    List<String> imageUrls,
+
+    @Schema(description = "푸드트럭 이름", example = "크래미 분식집")
+    String name,
+
+    @Schema(description = "푸드트럭 태그", example = "#간편식 #디저트")
+    String description,
+
+    @Schema(description = "오늘의 운영 시간 요약", example = "13일(수) 13:00 - 20:00")
+    String operatingString,
+
+    @Schema(description = "해당 푸드트럭의 메뉴 목록")
+    List<FoodTruckMenuResDto> menus,
+
+    @Schema(description = "맛있어요(좋아요) 누적 개수", example = "150")
+    int likeCount,
+
+    @Schema(description = "현재 접속한 사용자의 좋아요 클릭 여부", example = "true")
+    boolean isLiked
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckMenuResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/dto/FoodTruckMenuResDto.java
@@ -1,0 +1,16 @@
+package com.ds.dsfest.domain.foodtruck.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "푸드트럭 단일 메뉴 정보")
+public record FoodTruckMenuResDto(
+    @Schema(description = "메뉴 이름", example = "크래미 김밥")
+    String menuName,
+
+    @Schema(description = "메뉴 가격", example = "8000")
+    Integer price,
+
+    @Schema(description = "비건 메뉴 여부", example = "true")
+    boolean isVegan
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruck.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruck.java
@@ -28,6 +28,7 @@ public class FoodTruck extends BaseEntity {
   @Column(columnDefinition = "TEXT")
   private String description;
 
+  @OrderBy("id ASC")
   @OneToMany(mappedBy = "foodTruck", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<FoodTruckImage> foodTruckImages = new ArrayList<>();
 

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruck.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruck.java
@@ -1,22 +1,13 @@
 package com.ds.dsfest.domain.foodtruck.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
 import com.ds.dsfest.global.common.BaseEntity;
-
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,8 +28,8 @@ public class FoodTruck extends BaseEntity {
   @Column(columnDefinition = "TEXT")
   private String description;
 
-  @Column(nullable = false, length = 500)
-  private String imageUrl;
+  @OneToMany(mappedBy = "foodTruck", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<FoodTruckImage> foodTruckImages = new ArrayList<>();
 
   @OneToMany(mappedBy = "foodTruck", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<FoodTruckMenu> menus = new ArrayList<>();

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckImage.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckImage.java
@@ -1,0 +1,24 @@
+package com.ds.dsfest.domain.foodtruck.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "food_truck_images")
+public class FoodTruckImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_truck_id", nullable = false)
+    private FoodTruck foodTruck;
+
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckMenu.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/entity/FoodTruckMenu.java
@@ -33,4 +33,7 @@ public class FoodTruckMenu {
 
   @Column(nullable = false)
   private int price;
+
+  @Column(nullable = false, columnDefinition = "boolean default false")
+  private boolean isVegan;
 }

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckMapper.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/mapper/FoodTruckMapper.java
@@ -18,10 +18,10 @@ public class FoodTruckMapper {
      * @param likeCount     좋아요 개수
      * @return 푸드트럭 리스트 응답 DTO
      */
-    public FoodTruckListResDto toFoodTruckListResDto(FoodTruck foodTruck, String operatingDays, Integer likeCount, Boolean isOpen) {
+    public FoodTruckListResDto toFoodTruckListResDto(FoodTruck foodTruck,String thumbnailUrl, String operatingDays, Integer likeCount, Boolean isOpen) {
         return new FoodTruckListResDto(
             foodTruck.getId(),
-            foodTruck.getImageUrl(),
+            thumbnailUrl,
             foodTruck.getName(),
             foodTruck.getRepresentativeMenu(),
             foodTruck.getDescription(),

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckMenuRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/repository/FoodTruckMenuRepository.java
@@ -1,0 +1,14 @@
+package com.ds.dsfest.domain.foodtruck.repository;
+
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
+import com.ds.dsfest.domain.foodtruck.entity.FoodTruckMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FoodTruckMenuRepository extends JpaRepository<FoodTruckMenu, Long> {
+    /**
+     * 특정 푸드트럭에 속한 모든 메뉴를 조회합니다.
+     */
+    List<FoodTruckMenu> findByFoodTruck(FoodTruck foodTruck);
+}

--- a/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
+++ b/src/main/java/com/ds/dsfest/domain/foodtruck/service/FoodTruckService.java
@@ -1,13 +1,14 @@
 package com.ds.dsfest.domain.foodtruck.service;
 
 import com.ds.dsfest.domain.booth.exception.BoothErrorCode;
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckDetailResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckLikeResDto;
 import com.ds.dsfest.domain.foodtruck.dto.FoodTruckListResDto;
-import com.ds.dsfest.domain.foodtruck.entity.FoodTruck;
-import com.ds.dsfest.domain.foodtruck.entity.FoodTruckLike;
-import com.ds.dsfest.domain.foodtruck.entity.FoodTruckOperatingDay;
+import com.ds.dsfest.domain.foodtruck.dto.FoodTruckMenuResDto;
+import com.ds.dsfest.domain.foodtruck.entity.*;
 import com.ds.dsfest.domain.foodtruck.mapper.FoodTruckMapper;
 import com.ds.dsfest.domain.foodtruck.repository.FoodTruckLikeRepository;
+import com.ds.dsfest.domain.foodtruck.repository.FoodTruckMenuRepository;
 import com.ds.dsfest.domain.foodtruck.repository.FoodTruckRepository;
 import com.ds.dsfest.domain.user.entity.GuestUser;
 import com.ds.dsfest.domain.user.exception.UserErrorCode;
@@ -42,6 +43,7 @@ public class FoodTruckService {
     private final GuestUserRepository guestUserRepository;
     private final FoodTruckMapper foodTruckMapper;
     private final Clock clock;
+    private final FoodTruckMenuRepository foodTruckMenuRepository;
 
     @Value("${festival.start-date}")
     private String festivalStartDateStr;
@@ -51,8 +53,17 @@ public class FoodTruckService {
      *
      * @return 좋아요 개수가 포함된 푸드트럭 리스트 DTO 목록
      */
-    public List<FoodTruckListResDto> getFoodTruckList() {
+    public List<FoodTruckListResDto> getFoodTruckList(boolean isVegan) {
         List<FoodTruck> foodTrucks = foodTruckRepository.findAllWithOperatingDays();
+
+        /**
+         * isVegan == ture 인 트럭만 조회
+         */
+        if (isVegan) {
+            foodTrucks = foodTrucks.stream()
+                .filter(truck -> truck.getMenus().stream().anyMatch(FoodTruckMenu::isVegan))
+                .collect(Collectors.toList());
+        }
 
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDate today = now.toLocalDate();
@@ -88,7 +99,10 @@ public class FoodTruckService {
 
                 int likeCount = Math.toIntExact(foodTruckLikeRepository.countByFoodTruck(truck)); // 해당 트럭의 좋아요 개수 조회
 
-                return foodTruckMapper.toFoodTruckListResDto(truck, operatingDaysString, likeCount, isOpen);
+                String thumbnailUrl = truck.getFoodTruckImages().isEmpty() ?
+                    "" : truck.getFoodTruckImages().get(0).getImageUrl();
+
+                return foodTruckMapper.toFoodTruckListResDto(truck, thumbnailUrl, operatingDaysString, likeCount, isOpen);
             })
             .collect(Collectors.toList());
 
@@ -162,5 +176,67 @@ public class FoodTruckService {
             return festivalDay;
         }
         return -1;
+    }
+
+    /**
+     * 특정 푸드트럭의 상세 정보를 조회합니다.
+     * @return 푸드트럭 상세 정보 DTO
+     */
+    public FoodTruckDetailResDto getFoodTruckDetail(Long foodTruckId, UUID guestUuid) {
+
+        FoodTruck truck = foodTruckRepository.findById(foodTruckId)
+            .orElseThrow(() -> new CustomException(BoothErrorCode.BOOTH_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDate today = now.toLocalDate();
+        int currentFestivalDay = getFestivalDayFromDate(today);
+
+        String operatingString = "운영 정보 없음";
+        Optional<FoodTruckOperatingDay> todaySchedule = truck.getOperatingDays().stream()
+            .filter(schedule -> schedule.getFestivalDay() == currentFestivalDay)
+            .findFirst();
+
+        if (todaySchedule.isPresent()) {
+            LocalTime start = todaySchedule.get().getStartTime();
+            LocalTime end = todaySchedule.get().getEndTime();
+            String dayOfWeek = today.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+            operatingString = String.format("%d일(%s) %s - %s",
+                today.getDayOfMonth(), dayOfWeek, start.format(timeFormatter), end.format(timeFormatter));
+        }
+
+        List<FoodTruckMenuResDto> menuList = foodTruckMenuRepository.findByFoodTruck(truck)
+            .stream()
+            .map(menu -> new FoodTruckMenuResDto(
+                menu.getMenuName(),
+                menu.getPrice(),
+                menu.isVegan()
+            ))
+            .collect(Collectors.toList());
+
+        int likeCount = Math.toIntExact(foodTruckLikeRepository.countByFoodTruck(truck));
+
+        boolean isLiked = false;
+        if (guestUuid != null) {
+            Optional<GuestUser> guestUser = guestUserRepository.findById(guestUuid);
+            if (guestUser.isPresent()) {
+                isLiked = foodTruckLikeRepository.findByGuestUserAndFoodTruck(guestUser.get(), truck).isPresent();
+            }
+        }
+
+        List<String> images = truck.getFoodTruckImages().stream()
+            .map(FoodTruckImage::getImageUrl)
+            .collect(Collectors.toList());
+
+        return new FoodTruckDetailResDto(
+            truck.getId(),
+            images,
+            truck.getName(),
+            truck.getDescription(),
+            operatingString,
+            menuList,
+            likeCount,
+            isLiked
+        );
     }
 }


### PR DESCRIPTION
- 다중 이미지 처리 위해 FoodTruckImage 엔티티 설정

## #️⃣ 연관된 이슈
- close #45 

## 📝 작업 내용
- **푸드트럭 상세 조회 API 구현**
  - 특정 푸드트럭의 상세 정보(운영시간, 좋아요 개수 및 여부, 메뉴 리스트) 반환
  - 다중 이미지 처리를 위해 `FoodTruckImage` 엔티티 연동 (`imageUrls` 배열로 반환)
- **푸드트럭 리스트 API 조회 로직 수정 (비건 필터 적용)**
  - `is-vegan=true` 쿼리 파라미터 전달 시, 비건 메뉴(`isVegan=true`)를 하나라도 포함한 트럭만 필터링하여 반환
  - `is-vegan=false` 또는 미전달 시 전체 트럭 반환 (기본값)
  - `FoodTruckImage` 분리에 따라, 리스트의 썸네일은 등록된 이미지 중 첫 번째(0번째 인덱스) 사진을 추출하도록 수정

## 📌 API 목록
- `[GET] /api/food-trucks/{foodTruckId}` : 푸드트럭 상세 조회 
- `[GET] /api/food-trucks?is-vegan={boolean}` : 푸드트럭 리스트 조회 (쿼리 파라미터 추가)

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- **ERD 및 엔티티 변경 사항:** : 푸드트럭 다중 이미지 처리를 위해 `FoodTruckImage` 테이블이 분리되었습니다. 
  - ERD 상에 `food_trucks` 테이블의 `image_url` 컬럼이 남아있는데, 이를 삭제하고 `FoodTruckImage` 테이블로 완전히 이관하는 방향으로 코드를 작성했습니다.
- 상세 조회 시 `guest_uuid` 헤더는 필수가 아니지만, 보내주셔야 현재 접속자의 좋아요 여부(`isLiked`)를 정확히 판별할 수 있습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 음식 트럭 목록에 비건 필터 추가 (쿼리로 활성화 가능, 기본 비활성)
  * 음식 트럭 상세 조회 추가 — 이미지 목록, 메뉴(항목별 비건 표기), 운영 시간, 좋아요 상태 포함
  * 요청에 따른 사용자(게스트) 좋아요 여부 반영

* **개선사항**
  * 음식 트럭 이미지 다중 관리 및 썸네일 제공 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->