### PR TITLE
Feat: 사진 콘테스트 이벤트 상태 및 시간 조회

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
@@ -1,0 +1,25 @@
+package com.ds.dsfest.domain.photocontest.controller;
+
+import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
+import com.ds.dsfest.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/photo-contest")
+public class PhotoContestController implements PhotoContestControllerDocs {
+
+    private final PhotoContestService photoContestService;
+
+    @GetMapping("/status")
+    @Override
+    public ResponseEntity<ApiResponse<PhotoContestStatusResDto>> getContestStatus() {
+        PhotoContestStatusResDto result = photoContestService.getContestStatus();
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
@@ -1,0 +1,14 @@
+package com.ds.dsfest.domain.photocontest.controller;
+
+import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Photo Contest", description = "사진 콘테스트 관련 API")
+public interface PhotoContestControllerDocs {
+
+    @Operation(summary = "사진 콘테스트 상태 조회", description = "현재 콘테스트 상태(ACCEPTING, VOTING, ENDED)를 반환합니다.")
+    ResponseEntity<ApiResponse<PhotoContestStatusResDto>> getContestStatus();
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoContestStatusResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoContestStatusResDto.java
@@ -1,0 +1,18 @@
+package com.ds.dsfest.domain.photocontest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "사진 콘테스트 상태 응답 DTO")
+public record PhotoContestStatusResDto(
+    @Schema(description = "콘테스트 상태 (ACCEPTING: 응모 중, VOTING: 투표 중, ENDED: 종료됨)", example = "ACCEPTING")
+    String status,
+
+    @Schema(description = "현재 상태의 시작 시간", example = "2026-05-13T09:00:00")
+    LocalDateTime startTime,
+
+    @Schema(description = "현재 상태의 마감 시간 (카운트다운용)", example = "2026-05-14T20:00:00")
+    LocalDateTime endTime
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoContestSetting.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoContestSetting.java
@@ -23,9 +23,9 @@ public class PhotoContestSetting extends BaseEntity {
   @Column(nullable = false, length = 20)
   private PhotoContestStatus status;
 
-  @Column(name = "start_time")
+    @Column(name = "start_time", nullable = false)
   private LocalDateTime startTime;
 
-  @Column(name = "end_time")
+    @Column(name = "end_time", nullable = false)
   private LocalDateTime endTime;
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoContestSetting.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoContestSetting.java
@@ -1,20 +1,13 @@
 package com.ds.dsfest.domain.photocontest.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
 import com.ds.dsfest.domain.photocontest.constant.PhotoContestStatus;
 import com.ds.dsfest.global.common.BaseEntity;
-
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,4 +22,10 @@ public class PhotoContestSetting extends BaseEntity {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)
   private PhotoContestStatus status;
+
+  @Column(name = "start_time")
+  private LocalDateTime startTime;
+
+  @Column(name = "end_time")
+  private LocalDateTime endTime;
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoContestSettingRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoContestSettingRepository.java
@@ -1,0 +1,7 @@
+package com.ds.dsfest.domain.photocontest.repository;
+
+import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoContestSettingRepository extends JpaRepository<PhotoContestSetting, Long> {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -1,0 +1,33 @@
+package com.ds.dsfest.domain.photocontest.service;
+
+import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
+import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
+import com.ds.dsfest.global.exception.CustomException;
+import com.ds.dsfest.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PhotoContestService {
+
+    private final PhotoContestSettingRepository photoContestSettingRepository;
+
+    /**
+     * 사진 콘테스트의 현재 상태 및 마감 시간을 반환합니다.
+     */
+    public PhotoContestStatusResDto getContestStatus() {
+
+        PhotoContestSetting setting = photoContestSettingRepository.findById(1L)
+            .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
+
+        return new PhotoContestStatusResDto(
+            setting.getStatus().name(),
+            setting.getStartTime(),
+            setting.getEndTime()
+        );
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.photocontest.service;
 
+import com.ds.dsfest.domain.photocontest.constant.PhotoContestStatus;
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
 import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
@@ -8,6 +9,8 @@ import com.ds.dsfest.global.exception.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +27,25 @@ public class PhotoContestService {
         PhotoContestSetting setting = photoContestSettingRepository.findById(1L)
             .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
 
+        if (setting.getStartTime() == null || setting.getEndTime() == null) {
+            throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+        }
+        if (!setting.getStartTime().isBefore(setting.getEndTime())) {
+            throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        PhotoContestStatus derivedStatus;
+        if (now.isBefore(setting.getStartTime())) {
+            derivedStatus = PhotoContestStatus.ACCEPTING;
+        } else if (now.isBefore(setting.getEndTime())) {
+            derivedStatus = PhotoContestStatus.VOTING;
+        } else {
+            derivedStatus = PhotoContestStatus.ENDED;
+        }
+
         return new PhotoContestStatusResDto(
-            setting.getStatus().name(),
+            derivedStatus.name(),
             setting.getStartTime(),
             setting.getEndTime()
         );


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #47 

## 📝 작업 내용
- **사진 콘테스트 상태 조회 API 구현**
  - 현재 콘테스트의 진행 상태(`ACCEPTING`, `VOTING`, `ENDED`) 반환 로직 구현
  - 단일 설정 데이터(`id=1`) 조회 및 데이터 부재 시 예외 처리(`GlobalErrorCode.NOT_FOUND`) 적용
- **엔티티 수정 및 타이머 동기화 로직 추가**
  - 프론트엔드의 유연한 카운트다운(타이머) 처리를 위해 `PhotoContestSetting` 엔티티에 `startTime`, `endTime` 필드 추가
  - `PhotoContestStatusResDto` 응답에 상태와 함께 시작/종료 시간이 ISO-8601 형식으로 포함되도록 설계
- **Swagger API 명세서(Docs) 업데이트**

## 📌 API 목록
- `[GET] /api/photo-contest/status`

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- API 응답으로 `status`와 함께 `startTime`, `endTime`이 내려갑니다. 
  - 해당 시간을 기준으로 프론트에서 카운트다운 타이머를 돌려주시면 됩니다. (응모 기간 `ACCEPTING`에는 오픈채팅방 링크 연결, 투표 기간 `VOTING`에는 투표 화면 연결)
- DB에서 유연하게 이벤트 시간을 관리하기 위해 `PhotoContestSetting` 테이블에 컬럼 2개(`start_time`, `end_time`)가 추가되었습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 공모 현황 조회 API 추가 — 사용자가 /api/photo-contest/status에서 현재 상태(ACCEPTING, VOTING, ENDED), 시작 시간 및 종료 시간을 조회할 수 있습니다. 상태는 현재 시점에 따라 자동으로 판단됩니다.
* **문서**
  * Swagger/OpenAPI 문서 추가로 엔드포인트와 응답 형식이 명확히 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->