### PR TITLE
Feat: 사진 콘테스트 출품작 상세 조회 API

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
@@ -18,6 +18,9 @@ public class PhotoContestController implements PhotoContestControllerDocs {
 
     private final PhotoContestService photoContestService;
 
+    /**
+     * 사진 콘테스트 이벤트 현황 상태
+     */
     @GetMapping("/status")
     @Override
     public ResponseEntity<ApiResponse<PhotoContestStatusResDto>> getContestStatus() {
@@ -25,6 +28,12 @@ public class PhotoContestController implements PhotoContestControllerDocs {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
+    /**
+     * 사진 콘테스트 출품작 상세 조회 (A.7.2.3)
+     *
+     * @param photoEntryId 상세 조회할 출품작의 고유 ID
+     * @return 출품작 상세 정보(제목, 작성자, 설명, 이미지 URL)를 담은 PhotoDetailResDto
+     */
     @GetMapping("/{photoEntryId}")
     @Override
     public ResponseEntity<ApiResponse<PhotoDetailResDto>> getPhotoDetail(

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
@@ -1,11 +1,13 @@
 package com.ds.dsfest.domain.photocontest.controller;
 
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
 import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
 import com.ds.dsfest.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +22,15 @@ public class PhotoContestController implements PhotoContestControllerDocs {
     @Override
     public ResponseEntity<ApiResponse<PhotoContestStatusResDto>> getContestStatus() {
         PhotoContestStatusResDto result = photoContestService.getContestStatus();
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @GetMapping("/{photoEntryId}")
+    @Override
+    public ResponseEntity<ApiResponse<PhotoDetailResDto>> getPhotoDetail(
+        @PathVariable(name = "photoEntryId") Long photoEntryId
+    ) {
+        PhotoDetailResDto result = photoContestService.getPhotoDetail(photoEntryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
@@ -1,14 +1,21 @@
 package com.ds.dsfest.domain.photocontest.controller;
 
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
 import com.ds.dsfest.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Photo Contest", description = "사진 콘테스트 관련 API")
 public interface PhotoContestControllerDocs {
 
     @Operation(summary = "사진 콘테스트 상태 조회", description = "현재 콘테스트 상태(ACCEPTING, VOTING, ENDED)를 반환합니다.")
     ResponseEntity<ApiResponse<PhotoContestStatusResDto>> getContestStatus();
+
+    @Operation(summary = "사진 상세 조회", description = "특정 사진의 상세 정보를 조회합니다.")
+    ResponseEntity<ApiResponse<PhotoDetailResDto>> getPhotoDetail(
+        @PathVariable(name = "photoEntryId") Long photoEntryId
+    );
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoDetailResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoDetailResDto.java
@@ -1,7 +1,14 @@
 package com.ds.dsfest.domain.photocontest.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
+/**
+ * 사진 콘테스트 출품작 상세 정보 조회를 위한 응답 DTO
+ * * @param id 사진 고유 ID
+ * @param title 사진 제목
+ * @param authorName 출품자 이름
+ * @param description 사진 설명
+ * @param imageUrl 사진 이미지 URL
+ */
 @Schema(description = "사진 상세 정보 응답 DTO")
 public record PhotoDetailResDto(
     @Schema(description = "사진 고유 ID", example = "1")

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoDetailResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoDetailResDto.java
@@ -1,0 +1,31 @@
+package com.ds.dsfest.domain.photocontest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사진 상세 정보 응답 DTO")
+public record PhotoDetailResDto(
+    @Schema(description = "사진 고유 ID", example = "1")
+    Long id,
+
+    @Schema(description = "사진 제목", example = "우리들의 빛나는 청춘")
+    String title,
+
+    @Schema(description = "출품자 이름", example = "김덕우")
+    String authorName,
+
+    @Schema(description = "사진 상세 설명", example = "축제 첫날 동기들과 함께 찍은 사진입니다.")
+    String description,
+
+    @Schema(description = "이미지 URL", example = "https://example.com/photo1.jpg")
+    String imageUrl
+) {
+    public static PhotoDetailResDto from(com.ds.dsfest.domain.photocontest.entity.PhotoEntry entity) {
+        return new PhotoDetailResDto(
+            entity.getId(),
+            entity.getTitle(),
+            entity.getAuthorName(),
+            entity.getDescription(),
+            entity.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
@@ -1,0 +1,7 @@
+package com.ds.dsfest.domain.photocontest.repository;
+
+import com.ds.dsfest.domain.photocontest.entity.PhotoEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoEntryRepository extends JpaRepository<PhotoEntry, Long> {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -2,8 +2,10 @@ package com.ds.dsfest.domain.photocontest.service;
 
 import com.ds.dsfest.domain.photocontest.constant.PhotoContestStatus;
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
 import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
 import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
+import com.ds.dsfest.domain.photocontest.repository.PhotoEntryRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.exception.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import java.time.LocalDateTime;
 public class PhotoContestService {
 
     private final PhotoContestSettingRepository photoContestSettingRepository;
+    private final PhotoEntryRepository photoEntryRepository;
 
     /**
      * 사진 콘테스트의 현재 상태 및 마감 시간을 반환합니다.
@@ -49,5 +52,15 @@ public class PhotoContestService {
             setting.getStartTime(),
             setting.getEndTime()
         );
+    }
+
+    /**
+     * 사진 상세 정보를 조회합니다.
+     */
+    public PhotoDetailResDto getPhotoDetail(Long photoEntryId) {
+        com.ds.dsfest.domain.photocontest.entity.PhotoEntry photoEntry = photoEntryRepository.findById(photoEntryId)
+            .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
+
+        return PhotoDetailResDto.from(photoEntry);
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -55,7 +55,10 @@ public class PhotoContestService {
     }
 
     /**
-     * 사진 상세 정보를 조회합니다.
+     * 특정 출품작의 상세 정보를 조회합니다.
+     * * @param photoEntryId 조회할 출품작 ID
+     * @return 조회된 출품작 데이터를 담은 DTO
+     * @throws CustomException 해당 ID의 출품작이 존재하지 않을 경우 NOT_FOUND 예외 발생
      */
     public PhotoDetailResDto getPhotoDetail(Long photoEntryId) {
         com.ds.dsfest.domain.photocontest.entity.PhotoEntry photoEntry = photoEntryRepository.findById(photoEntryId)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #49 

## 📝 작업 내용
- **사진 콘테스트 출품작 상세 조회 API 구현**
  - `photoEntryId`를 경로 변수로 받아 해당 사진의 상세 정보를 반환하는 로직 구현
  - 출품작이 존재하지 않을 경우 `GlobalErrorCode.NOT_FOUND` (404) 예외 처리 적용
- **데이터 전달을 위한 DTO 및 Repository 구현**
  - 상세 정보(제목, 작성자, 설명, 이미지 URL)를 포함하는 `PhotoDetailResDto` 설계
- **Swagger API 명세서 연동 및 문서화**

## 📌 API 목록
- `[GET] /api/photo-contest/{photoEntryId}`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사진 ID로 특정 사진 항목의 상세 정보를 조회할 수 있는 엔드포인트가 추가되었습니다. 조회 결과로 제목, 작가명, 설명, 이미지 URL 등 상세 정보를 확인할 수 있습니다.

* **문서**
  * 해당 상세 조회 API가 문서화되어 API 설명서에서 사용법과 응답 형식을 참고할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->