### PR TITLE
Feat: 사진 콘테스트 목록 조회 API

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/photocontest/constant/PhotoContestStatus.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/constant/PhotoContestStatus.java
@@ -5,3 +5,4 @@ public enum PhotoContestStatus {
   VOTING,
   ENDED
 }
+

--- a/src/main/java/com/ds/dsfest/domain/photocontest/constant/PhotoTheme.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/constant/PhotoTheme.java
@@ -1,0 +1,7 @@
+package com.ds.dsfest.domain.photocontest.constant;
+
+public enum PhotoTheme {
+    YOUTH,       // 청춘
+    FESTIVAL,    // 축제 현장
+    DRESS_CODE   // 드레스코드
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
@@ -2,14 +2,12 @@ package com.ds.dsfest.domain.photocontest.controller;
 
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
 import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
 import com.ds.dsfest.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class PhotoContestController implements PhotoContestControllerDocs {
     }
 
     /**
-     * 사진 콘테스트 출품작 상세 조회 (A.7.2.3)
+     * 사진 콘테스트 출품작 상세 조회
      *
      * @param photoEntryId 상세 조회할 출품작의 고유 ID
      * @return 출품작 상세 정보(제목, 작성자, 설명, 이미지 URL)를 담은 PhotoDetailResDto
@@ -40,6 +38,17 @@ public class PhotoContestController implements PhotoContestControllerDocs {
         @PathVariable(name = "photoEntryId") Long photoEntryId
     ) {
         PhotoDetailResDto result = photoContestService.getPhotoDetail(photoEntryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    /**
+     * 사진 콘테스트 출품작 목록 조회
+     * 주제별로 그룹화된 리스트를 반환합니다.
+     */
+    @GetMapping
+    @Override
+    public ResponseEntity<ApiResponse<PhotoListResDto>> getPhotoList() {
+        PhotoListResDto result = photoContestService.getPhotoList();
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
@@ -2,6 +2,7 @@ package com.ds.dsfest.domain.photocontest.controller;
 
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
 import com.ds.dsfest.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,4 +19,7 @@ public interface PhotoContestControllerDocs {
     ResponseEntity<ApiResponse<PhotoDetailResDto>> getPhotoDetail(
         @PathVariable(name = "photoEntryId") Long photoEntryId
     );
+
+    @Operation(summary = "사진 목록 조회", description = "주제별(청춘, 축제, 드레스코드)로 분류된 사진 목록을 조회합니다.")
+    ResponseEntity<ApiResponse<PhotoListResDto>> getPhotoList();
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoListResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoListResDto.java
@@ -1,0 +1,40 @@
+package com.ds.dsfest.domain.photocontest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "사진 목록 무한 스크롤 응답 DTO")
+public record PhotoListResDto(
+    @Schema(description = "1. 자신의 청춘을 가장 잘 담은 사진 목록 (6개)")
+    List<PhotoSummaryDto> youthPhotos,
+
+    @Schema(description = "2. 축제 현장을 가장 잘 담은 사진 목록 (6개)")
+    List<PhotoSummaryDto> festivalPhotos,
+
+    @Schema(description = "3. 드레스코드를 가장 잘 살려 입은 사진 목록 (6개)")
+    List<PhotoSummaryDto> dressCodePhotos
+) {
+    @Schema(description = "사진 목록 요약 정보")
+    public record PhotoSummaryDto(
+        @Schema(description = "사진 고유 ID", example = "1")
+        Long photoEntryId,
+
+        @Schema(description = "사진 제목", example = "우리들의 빛나는 청춘")
+        String title,
+
+        @Schema(description = "출품자 이름", example = "김덕우")
+        String authorName,
+
+        @Schema(description = "이미지 URL (썸네일)", example = "https://example.com/photo1.jpg")
+        String imageUrl
+    ) {
+        public static PhotoSummaryDto from(com.ds.dsfest.domain.photocontest.entity.PhotoEntry entity) {
+            return new PhotoSummaryDto(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getAuthorName(),
+                entity.getImageUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoEntry.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoEntry.java
@@ -1,22 +1,14 @@
 package com.ds.dsfest.domain.photocontest.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
+import com.ds.dsfest.domain.photocontest.constant.PhotoTheme;
 import com.ds.dsfest.global.common.BaseEntity;
-
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,4 +34,8 @@ public class PhotoEntry extends BaseEntity {
 
   @OneToMany(mappedBy = "photoEntry", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<PhotoVote> votes = new ArrayList<>();
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private PhotoTheme theme;
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
@@ -9,5 +9,5 @@ public interface PhotoEntryRepository extends JpaRepository<PhotoEntry, Long> {
     /**
      * 모든 출품작을 생성 순으로 조회합니다.
      */
-    List<PhotoEntry> findAllByOrderByCreatedAtAsc();
+    List<PhotoEntry> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
@@ -3,5 +3,11 @@ package com.ds.dsfest.domain.photocontest.repository;
 import com.ds.dsfest.domain.photocontest.entity.PhotoEntry;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PhotoEntryRepository extends JpaRepository<PhotoEntry, Long> {
+    /**
+     * 모든 출품작을 생성 순으로 조회합니다.
+     */
+    List<PhotoEntry> findAllByOrderByCreatedAtAsc();
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -1,9 +1,12 @@
 package com.ds.dsfest.domain.photocontest.service;
 
 import com.ds.dsfest.domain.photocontest.constant.PhotoContestStatus;
+import com.ds.dsfest.domain.photocontest.constant.PhotoTheme;
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
 import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
+import com.ds.dsfest.domain.photocontest.entity.PhotoEntry;
 import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
 import com.ds.dsfest.domain.photocontest.repository.PhotoEntryRepository;
 import com.ds.dsfest.global.exception.CustomException;
@@ -13,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -65,5 +69,29 @@ public class PhotoContestService {
             .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
 
         return PhotoDetailResDto.from(photoEntry);
+    }
+
+    /**
+     * 사진 콘테스트 출품작 목록을 주제별로 분류하여 전체 조회합니다. (A.7.2.1)
+     */
+    public PhotoListResDto getPhotoList() {
+        List<PhotoEntry> allPhotos = photoEntryRepository.findAll();
+
+        List<PhotoListResDto.PhotoSummaryDto> youthPhotos = allPhotos.stream()
+            .filter(photo -> photo.getTheme() == PhotoTheme.YOUTH)
+            .map(PhotoListResDto.PhotoSummaryDto::from)
+            .toList();
+
+        List<PhotoListResDto.PhotoSummaryDto> festivalPhotos = allPhotos.stream()
+            .filter(photo -> photo.getTheme() == PhotoTheme.FESTIVAL)
+            .map(PhotoListResDto.PhotoSummaryDto::from)
+            .toList();
+
+        List<PhotoListResDto.PhotoSummaryDto> dressCodePhotos = allPhotos.stream()
+            .filter(photo -> photo.getTheme() == PhotoTheme.DRESS_CODE)
+            .map(PhotoListResDto.PhotoSummaryDto::from)
+            .toList();
+
+        return new PhotoListResDto(youthPhotos, festivalPhotos, dressCodePhotos);
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -75,7 +75,7 @@ public class PhotoContestService {
      * 사진 콘테스트 출품작 목록을 주제별로 분류하여 전체 조회합니다. (A.7.2.1)
      */
     public PhotoListResDto getPhotoList() {
-        List<PhotoEntry> allPhotos = photoEntryRepository.findAll();
+        List<PhotoEntry> allPhotos = photoEntryRepository.findAllByOrderByCreatedAtDesc();
 
         List<PhotoListResDto.PhotoSummaryDto> youthPhotos = allPhotos.stream()
             .filter(photo -> photo.getTheme() == PhotoTheme.YOUTH)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #51 

## 📝 작업 내용
- **기획서 및 피그마 요구사항(주제별 투표) 반영을 위한 로직 구현**
  - `PhotoTheme` Enum (YOUTH, FESTIVAL, DRESS_CODE) 생성 및 엔티티 연동
  - 프론트엔드에서 페이지별로 바로 렌더링할 수 있도록 3개의 배열로 분리하여 응답

## 📌 API 목록
- `[GET] /api/photo-contest`

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- `photo_entries` 테이블에 `theme` 컬럼이 추가되었습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 콘테스트 목록 조회 API 추가(무한 스크롤용 주제별 그룹화)
  * 사진을 테마별(청춘, 축제, 드레스코드)로 자동 분류하여 제공
  * 각 사진의 제목, 작성자, 썸네일을 포함한 요약 목록 반환

* **문서**
  * API 문서에 신규 목록 조회 엔드포인트 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->