### PR TITLE
Feat: 라이브톡 대화 주제

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -2,12 +2,12 @@ package com.ds.dsfest.domain.livetalk.controller;
 
 import java.util.List;
 
-import com.ds.dsfest.domain.livetalk.dto.ChatTopicResDto;
-import com.ds.dsfest.domain.livetalk.service.ChatTopicService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.ds.dsfest.domain.livetalk.dto.ChatMessageResDto;
+import com.ds.dsfest.domain.livetalk.dto.ChatTopicResDto;
+import com.ds.dsfest.domain.livetalk.service.ChatTopicService;
 import com.ds.dsfest.domain.livetalk.service.LiveTalkService;
 import com.ds.dsfest.global.response.ApiResponse;
 
@@ -46,11 +46,11 @@ public class LiveTalkController {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getUnreadCount(guestUuid)));
   }
 
-
   private final ChatTopicService chatTopicService;
-// 대화 주제
+
+  // 대화 주제
   @GetMapping("/topics/current")
   public ResponseEntity<ApiResponse<ChatTopicResDto>> getCurrentTopic() {
-      return ResponseEntity.ok(ApiResponse.onSuccess(chatTopicService.getCurrentTopic()));
+    return ResponseEntity.ok(ApiResponse.onSuccess(chatTopicService.getCurrentTopic()));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -50,7 +50,7 @@ public class LiveTalkController {
   private final ChatTopicService chatTopicService;
 // 대화 주제
   @GetMapping("/topics/current")
-    public ChatTopicResDto getCurrentTopic() {
-        return chatTopicService.getCurrentTopic();
-    }
+  public ResponseEntity<ApiResponse<ChatTopicResDto>> getCurrentTopic() {
+      return ResponseEntity.ok(ApiResponse.onSuccess(chatTopicService.getCurrentTopic()));
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -32,7 +32,7 @@ public class LiveTalkService {
   @Transactional(readOnly = true)
   public List<ChatMessageResDto> getRecentMessages() {
     return chatMessageRepository.findTop50ByOrderByCreatedAtDesc().stream()
-        .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
+        .sorted((a, b) -> a.getId().compareTo(b.getId()))
         .map(chatMessageMapper::toResDto)
         .toList();
   }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -3,7 +3,7 @@ package com.ds.dsfest.domain.livetalk.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-
+import java.util.Comparator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +32,7 @@ public class LiveTalkService {
   @Transactional(readOnly = true)
   public List<ChatMessageResDto> getRecentMessages() {
     return chatMessageRepository.findTop50ByOrderByCreatedAtDesc().stream()
-        .sorted((a, b) -> a.getId().compareTo(b.getId()))
+        .sorted(Comparator.comparing(ChatMessage::getCreatedAt).thenComparing(ChatMessage::getId))
         .map(chatMessageMapper::toResDto)
         .toList();
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) close #43 

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
라이브톡 대화 주제 기능 구현 

### 스크린샷 (선택)

## 📌 API 목록
/api/livetalk/topics/current

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
topicType - GENERAL / ARTIST 로 구분해서 아티스트일 경우엔 아티스트 목록으로 이동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 현재 주제 조회 API의 응답이 표준화된 래퍼(ResponseEntity + ApiResponse)로 반환되도록 변경되었습니다.
  * 최근 메시지 조회 시 동일한 생성 시각을 가진 항목들이 id를 보조 정렬 기준으로 사용해 결정론적으로 정렬되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->