### PR TITLE
Feat: 사진 콘테스트 투표 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ CLAUDE.md
 claude.md
 *.claude
 .claude_cache/
+
+

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestController.java
@@ -5,6 +5,7 @@ import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
 import com.ds.dsfest.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +21,7 @@ public class AdminPhotoContestController implements AdminPhotoContestControllerD
     private final PhotoContestService photoContestService;
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/results")
     public ResponseEntity<ApiResponse<Map<String, List<PhotoRankResDto>>>> getVoteResults() {
         Map<String, List<PhotoRankResDto>> results = photoContestService.getVoteResults();

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestController.java
@@ -1,0 +1,28 @@
+package com.ds.dsfest.domain.photocontest.controller;
+
+import com.ds.dsfest.domain.photocontest.dto.PhotoRankResDto;
+import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
+import com.ds.dsfest.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/photo-contest")
+public class AdminPhotoContestController implements AdminPhotoContestControllerDocs { // 💡 Docs 구현!
+
+    private final PhotoContestService photoContestService;
+
+    @Override
+    @GetMapping("/results")
+    public ResponseEntity<ApiResponse<Map<String, List<PhotoRankResDto>>>> getVoteResults() {
+        Map<String, List<PhotoRankResDto>> results = photoContestService.getVoteResults();
+        return ResponseEntity.ok(ApiResponse.onSuccess(results));
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestControllerDocs.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.List;
 import java.util.Map;
 
-@Tag(name = "Admin - 사진 콘테스트", description = "총학생회 전용 사진 콘테스트 투표 결과 관리 API")
+@Tag(name = "Admin Photo Contest", description = "총학생회 전용 사진 콘테스트 투표 결과 관리 API")
 @SecurityRequirement(name = "BearerAuth")
 public interface AdminPhotoContestControllerDocs {
 

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/AdminPhotoContestControllerDocs.java
@@ -1,0 +1,22 @@
+package com.ds.dsfest.domain.photocontest.controller;
+
+import com.ds.dsfest.domain.photocontest.dto.PhotoRankResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "Admin - 사진 콘테스트", description = "총학생회 전용 사진 콘테스트 투표 결과 관리 API")
+@SecurityRequirement(name = "BearerAuth")
+public interface AdminPhotoContestControllerDocs {
+
+    @Operation(
+        summary = "투표 결과 실시간 집계 조회",
+        description = "총학생회 관리자가 테마별 사진 득표수 랭킹을 조회합니다."
+    )
+    ResponseEntity<ApiResponse<Map<String, List<PhotoRankResDto>>>> getVoteResults();
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestController.java
@@ -3,8 +3,10 @@ package com.ds.dsfest.domain.photocontest.controller;
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoVoteReqDto;
 import com.ds.dsfest.domain.photocontest.service.PhotoContestService;
 import com.ds.dsfest.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -50,5 +52,17 @@ public class PhotoContestController implements PhotoContestControllerDocs {
     public ResponseEntity<ApiResponse<PhotoListResDto>> getPhotoList() {
         PhotoListResDto result = photoContestService.getPhotoList();
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    /**
+     * 사진 콘테스트 출품작 투표하기
+     */
+    @PostMapping("/vote")
+    @Override
+    public ResponseEntity<ApiResponse<String>> votePhotos(
+        @Valid @RequestBody PhotoVoteReqDto reqDto
+    ) {
+        photoContestService.votePhotos(reqDto);
+        return ResponseEntity.ok(ApiResponse.onSuccess("투표가 성공적으로 완료되었습니다."));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/controller/PhotoContestControllerDocs.java
@@ -3,9 +3,12 @@ package com.ds.dsfest.domain.photocontest.controller;
 import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
 import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
+import com.ds.dsfest.domain.photocontest.dto.PhotoVoteReqDto;
 import com.ds.dsfest.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -22,4 +25,9 @@ public interface PhotoContestControllerDocs {
 
     @Operation(summary = "사진 목록 조회", description = "주제별(청춘, 축제, 드레스코드)로 분류된 사진 목록을 조회합니다.")
     ResponseEntity<ApiResponse<PhotoListResDto>> getPhotoList();
+
+    @Operation(summary = "사진 투표하기", description = "선택한 3장의 사진에 투표합니다. (1인 1회 제한, 주제별 1장씩 필수)")
+    ResponseEntity<ApiResponse<String>> votePhotos(
+        @Valid @RequestBody PhotoVoteReqDto reqDto
+    );
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoRankResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoRankResDto.java
@@ -1,0 +1,10 @@
+package com.ds.dsfest.domain.photocontest.dto;
+
+public record PhotoRankResDto(
+    Long photoEntryId,
+    String title,
+    String authorName,
+    String theme,
+    Long voteCount
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoVoteReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoVoteReqDto.java
@@ -1,0 +1,26 @@
+package com.ds.dsfest.domain.photocontest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "사진 콘테스트 투표 요청 DTO")
+public record PhotoVoteReqDto(
+    @Schema(description = "학번 (8~9자리 숫자)", example = "20260000")
+    @NotBlank(message = "학번을 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{8,9}$", message = "올바른 학번 형식이 아닙니다.")
+    String studentId,
+
+    @Schema(description = "이름", example = "박덕우")
+    @NotBlank(message = "이름을 입력해주세요.")
+    String studentName,
+
+    @Schema(description = "선택한 사진 ID 목록 (반드시 3개)", example = "[1, 8, 15]")
+    @NotNull(message = "투표할 사진을 선택해주세요.")
+    @Size(min = 3, max = 3, message = "각 주제별로 1장씩, 총 3장을 선택해야 합니다.")
+    List<Long> photoEntryIds
+) {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoVoteReqDto.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/dto/PhotoVoteReqDto.java
@@ -21,6 +21,6 @@ public record PhotoVoteReqDto(
     @Schema(description = "선택한 사진 ID 목록 (반드시 3개)", example = "[1, 8, 15]")
     @NotNull(message = "투표할 사진을 선택해주세요.")
     @Size(min = 3, max = 3, message = "각 주제별로 1장씩, 총 3장을 선택해야 합니다.")
-    List<Long> photoEntryIds
+    List<@NotNull(message = "사진 ID는 null일 수 없습니다.") Long> photoEntryIds
 ) {
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
@@ -1,16 +1,7 @@
 package com.ds.dsfest.domain.photocontest.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-
 import com.ds.dsfest.global.common.BaseEntity;
-
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +20,11 @@ public class PhotoVote extends BaseEntity {
   @JoinColumn(name = "photo_entry_id", nullable = false)
   private PhotoEntry photoEntry;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "student_id", nullable = false)
-  private Student student;
+  @Column(nullable = false, length = 64)
+  private String voterKey;
+
+  public PhotoVote(PhotoEntry photoEntry, String voterKey) {
+      this.photoEntry = photoEntry;
+      this.voterKey = voterKey;
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
@@ -20,7 +20,7 @@ public class PhotoVote extends BaseEntity {
   @JoinColumn(name = "photo_entry_id", nullable = false)
   private PhotoEntry photoEntry;
 
-  @Column(nullable = false, length = 64)
+  @Column(nullable = false, length = 64, unique = true)
   private String voterKey;
 
   public PhotoVote(PhotoEntry photoEntry, String voterKey) {

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/VerifiedStudent.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/VerifiedStudent.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,13 +11,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "students")
-public class Student {
+@Table(name = "verified_students")
+public class VerifiedStudent {
 
-  @Id
-  @Column(name = "student_id", length = 20)
-  private String studentId;
+    @Id
+    @Column(name = "hashed_identity", length = 64)
+    private String hashedIdentity; // SHA-256 해시값 (64자)
 
-  @Column(nullable = false, length = 50)
-  private String studentName;
+    public VerifiedStudent(String hashedIdentity) {
+        this.hashedIdentity = hashedIdentity;
+    }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoVoteRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoVoteRepository.java
@@ -1,0 +1,20 @@
+package com.ds.dsfest.domain.photocontest.repository;
+
+import com.ds.dsfest.domain.photocontest.entity.PhotoVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PhotoVoteRepository extends JpaRepository<PhotoVote, Long> {
+    boolean existsByVoterKey(String voterKey);
+
+    /**
+     * 사진별 투표 수를 집계하여 결과가 많은 순으로 정렬
+     */
+    @Query("SELECT v.photoEntry.id, COUNT(v) as voteCount " +
+        "FROM PhotoVote v " +
+        "GROUP BY v.photoEntry.id " +
+        "ORDER BY voteCount DESC")
+    List<Object[]> countVotesPerPhoto();
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/VerifiedStudentRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/VerifiedStudentRepository.java
@@ -1,0 +1,7 @@
+package com.ds.dsfest.domain.photocontest.repository;
+
+import com.ds.dsfest.domain.photocontest.entity.VerifiedStudent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VerifiedStudentRepository extends JpaRepository<VerifiedStudent, String> {
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -2,21 +2,25 @@ package com.ds.dsfest.domain.photocontest.service;
 
 import com.ds.dsfest.domain.photocontest.constant.PhotoContestStatus;
 import com.ds.dsfest.domain.photocontest.constant.PhotoTheme;
-import com.ds.dsfest.domain.photocontest.dto.PhotoContestStatusResDto;
-import com.ds.dsfest.domain.photocontest.dto.PhotoDetailResDto;
-import com.ds.dsfest.domain.photocontest.dto.PhotoListResDto;
+import com.ds.dsfest.domain.photocontest.dto.*;
 import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
 import com.ds.dsfest.domain.photocontest.entity.PhotoEntry;
+import com.ds.dsfest.domain.photocontest.entity.PhotoVote;
 import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
 import com.ds.dsfest.domain.photocontest.repository.PhotoEntryRepository;
+import com.ds.dsfest.domain.photocontest.repository.PhotoVoteRepository;
+import com.ds.dsfest.domain.photocontest.repository.VerifiedStudentRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.exception.GlobalErrorCode;
+import com.ds.dsfest.global.util.IdentityHasher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +29,8 @@ public class PhotoContestService {
 
     private final PhotoContestSettingRepository photoContestSettingRepository;
     private final PhotoEntryRepository photoEntryRepository;
+    private final PhotoVoteRepository photoVoteRepository;
+    private final VerifiedStudentRepository verifiedStudentRepository;
 
     /**
      * 사진 콘테스트의 현재 상태 및 마감 시간을 반환합니다.
@@ -72,7 +78,7 @@ public class PhotoContestService {
     }
 
     /**
-     * 사진 콘테스트 출품작 목록을 주제별로 분류하여 전체 조회합니다. (A.7.2.1)
+     * 사진 콘테스트 출품작 목록을 주제별로 분류하여 전체 조회합니다.
      */
     public PhotoListResDto getPhotoList() {
         List<PhotoEntry> allPhotos = photoEntryRepository.findAllByOrderByCreatedAtDesc();
@@ -93,5 +99,84 @@ public class PhotoContestService {
             .toList();
 
         return new PhotoListResDto(youthPhotos, festivalPhotos, dressCodePhotos);
+    }
+
+    /**
+     * 사진 콘테스트 투표를 검증하고 저장합니다.
+     */
+    @Transactional
+    public void votePhotos(PhotoVoteReqDto reqDto) {
+        String currentHash = IdentityHasher.hashIdentity(reqDto.studentId(), reqDto.studentName(), "재학생"); // 재학생 해시
+        String leaveHash = IdentityHasher.hashIdentity("학사", reqDto.studentId(), "휴학생"); // 휴학생 해시
+
+        String voterKey = null;
+
+        if (verifiedStudentRepository.existsById(currentHash)) { // 재학생 명단
+            voterKey = currentHash;
+        }
+        else if (verifiedStudentRepository.existsById(leaveHash)) { // 휴학생 명단 ('학사' 키워드)
+            voterKey = leaveHash;
+        }
+        else {
+            throw new CustomException(GlobalErrorCode.NOT_FOUND);
+        }
+
+        /**
+         * 중복 투표 검증 (이미 이 해시로 투표했는지 확인)
+         */
+        if (photoVoteRepository.existsByVoterKey(voterKey)) {
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+
+        /**
+         * 선택한 사진들 조회 및 검증
+         */
+        List<PhotoEntry> selectedPhotos = photoEntryRepository.findAllById(reqDto.photoEntryIds());
+        if (selectedPhotos.size() != 3) {
+            throw new CustomException(GlobalErrorCode.NOT_FOUND);
+        }
+
+        /**
+         * 주제(Theme) 중복 체크
+         */
+        long themeCount = selectedPhotos.stream().map(PhotoEntry::getTheme).distinct().count();
+        if (themeCount != 3) {
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+
+        /**
+         * 투표 내역 저장
+         */
+        String finalVoterKey = voterKey;
+        List<PhotoVote> votes = selectedPhotos.stream()
+            .map(photo -> new PhotoVote(photo, finalVoterKey))
+            .toList();
+
+        photoVoteRepository.saveAll(votes);
+    }
+
+    /**
+     * 총 학생용 투표 결과 집계 (테마별 분류)
+     */
+    @Transactional(readOnly = true)
+    public Map<String, List<PhotoRankResDto>> getVoteResults() {
+        List<Object[]> results = photoVoteRepository.countVotesPerPhoto();
+
+        List<PhotoRankResDto> allRanks = results.stream().map(result -> {
+            Long photoId = (Long) result[0];
+            Long count = (Long) result[1];
+            PhotoEntry photo = photoEntryRepository.findById(photoId).orElseThrow();
+
+            return new PhotoRankResDto(
+                photo.getId(),
+                photo.getTitle(),
+                photo.getAuthorName(),
+                photo.getTheme().name(),
+                count
+            );
+        }).toList();
+
+        return allRanks.stream()
+            .collect(Collectors.groupingBy(PhotoRankResDto::theme));
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
@@ -23,37 +23,41 @@ public class StudentDataInitializer implements ApplicationRunner {
 
     private final VerifiedStudentRepository verifiedStudentRepository;
 
-    /**
-     * 환경변수 STUDENT_DATA_PATH를 읽어오며, 기본값은 리눅스 경로로 설정
-     */
     @Value("${STUDENT_DATA_PATH:/home/ubuntu/data/}")
     private String csvPath;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) throws Exception {
-        /**
-         * DB에 이미 데이터가 있으면 실행하지 않음
-         */
         if (verifiedStudentRepository.count() > 0) return;
 
         List<VerifiedStudent> allVerified = new ArrayList<>();
-
-        /**
-         * 경로 뒤에 /가 없을 수도 있으니 체크하는 로직
-         */
         String formattedPath = csvPath.endsWith("/") || csvPath.endsWith("\\") ? csvPath : csvPath + File.separator;
 
-        processAndSecurityDelete(formattedPath + "current_students.csv", "재학생", allVerified);
-        processAndSecurityDelete(formattedPath + "leave_students.csv", "휴학생", allVerified);
+        processFile(formattedPath + "current_students.csv", "재학생", allVerified);
+        processFile(formattedPath + "leave_students.csv", "휴학생", allVerified);
 
         if (!allVerified.isEmpty()) {
             verifiedStudentRepository.saveAll(allVerified);
-            log.info("RDS DB에 해시 데이터 저장 완료. 원본 파일은 서버에서 삭제되었습니다.");
+            log.info("RDS DB에 해시 데이터 저장 완료.");
+
+            deleteSecurityFiles(formattedPath);
         }
     }
 
-    private void processAndSecurityDelete(String filePath, String status, List<VerifiedStudent> list) {
+    private void deleteSecurityFiles(String path) {
+        String[] fileNames = {"current_students.csv", "leave_students.csv"};
+        for (String fileName : fileNames) {
+            File file = new File(path + fileName);
+            if (file.exists() && !csvPath.contains("classpath")) {
+                if (file.delete()) {
+                    log.info("보안을 위해 원본 파일이 삭제되었습니다: {}", fileName);
+                }
+            }
+        }
+    }
+
+    private void processFile(String filePath, String status, List<VerifiedStudent> list) {
         File file = new File(filePath);
         if (!file.exists()) {
             log.warn("파일을 찾을 수 없습니다: {}", filePath);
@@ -71,15 +75,6 @@ public class StudentDataInitializer implements ApplicationRunner {
             }
         } catch (Exception e) {
             log.error("파일 처리 중 오류 발생: {}", e.getMessage());
-        } finally {
-            /**
-             * 읽기가 끝난 후 실제 파일 삭제 (단, classpath 설정이 아닐 때만)
-             */
-            if (file.exists() && !csvPath.contains("classpath")) {
-                if (file.delete()) {
-                    log.info("보안을 위해 원본 파일이 삭제되었습니다: {}", filePath);
-                }
-            }
         }
     }
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
@@ -1,0 +1,85 @@
+package com.ds.dsfest.domain.photocontest.service;
+
+import com.ds.dsfest.domain.photocontest.entity.VerifiedStudent;
+import com.ds.dsfest.domain.photocontest.repository.VerifiedStudentRepository;
+import com.ds.dsfest.global.util.IdentityHasher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudentDataInitializer implements ApplicationRunner {
+
+    private final VerifiedStudentRepository verifiedStudentRepository;
+
+    /**
+     * 환경변수 STUDENT_DATA_PATH를 읽어오며, 기본값은 리눅스 경로로 설정
+     */
+    @Value("${STUDENT_DATA_PATH:/home/ubuntu/data/}")
+    private String csvPath;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) throws Exception {
+        /**
+         * DB에 이미 데이터가 있으면 실행하지 않음
+         */
+        if (verifiedStudentRepository.count() > 0) return;
+
+        List<VerifiedStudent> allVerified = new ArrayList<>();
+
+        /**
+         * 경로 뒤에 /가 없을 수도 있으니 체크하는 로직
+         */
+        String formattedPath = csvPath.endsWith("/") || csvPath.endsWith("\\") ? csvPath : csvPath + File.separator;
+
+        processAndSecurityDelete(formattedPath + "current_students.csv", "재학생", allVerified);
+        processAndSecurityDelete(formattedPath + "leave_students.csv", "휴학생", allVerified);
+
+        if (!allVerified.isEmpty()) {
+            verifiedStudentRepository.saveAll(allVerified);
+            log.info("RDS DB에 해시 데이터 저장 완료. 원본 파일은 서버에서 삭제되었습니다.");
+        }
+    }
+
+    private void processAndSecurityDelete(String filePath, String status, List<VerifiedStudent> list) {
+        File file = new File(filePath);
+        if (!file.exists()) {
+            log.warn("파일을 찾을 수 없습니다: {}", filePath);
+            return;
+        }
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] data = line.split(",");
+                if (data.length >= 2) {
+                    String hash = IdentityHasher.hashIdentity(data[0].trim(), data[1].trim(), status);
+                    list.add(new VerifiedStudent(hash));
+                }
+            }
+        } catch (Exception e) {
+            log.error("파일 처리 중 오류 발생: {}", e.getMessage());
+        } finally {
+            /**
+             * 읽기가 끝난 후 실제 파일 삭제 (단, classpath 설정이 아닐 때만)
+             */
+            if (file.exists() && !csvPath.contains("classpath")) {
+                if (file.delete()) {
+                    log.info("보안을 위해 원본 파일이 삭제되었습니다: {}", filePath);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/StudentDataInitializer.java
@@ -10,8 +10,13 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +33,7 @@ public class StudentDataInitializer implements ApplicationRunner {
 
     @Override
     @Transactional
-    public void run(ApplicationArguments args) throws Exception {
+    public void run(ApplicationArguments args) {
         if (verifiedStudentRepository.count() > 0) return;
 
         List<VerifiedStudent> allVerified = new ArrayList<>();
@@ -41,7 +46,12 @@ public class StudentDataInitializer implements ApplicationRunner {
             verifiedStudentRepository.saveAll(allVerified);
             log.info("RDS DB에 해시 데이터 저장 완료.");
 
-            deleteSecurityFiles(formattedPath);
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    deleteSecurityFiles(formattedPath);
+                }
+            });
         }
     }
 
@@ -51,7 +61,7 @@ public class StudentDataInitializer implements ApplicationRunner {
             File file = new File(path + fileName);
             if (file.exists() && !csvPath.contains("classpath")) {
                 if (file.delete()) {
-                    log.info("보안을 위해 원본 파일이 삭제되었습니다: {}", fileName);
+                    log.info("보안 삭제 완료: {}", fileName);
                 }
             }
         }
@@ -74,7 +84,8 @@ public class StudentDataInitializer implements ApplicationRunner {
                 }
             }
         } catch (Exception e) {
-            log.error("파일 처리 중 오류 발생: {}", e.getMessage());
+            log.error("파일 처리 중 치명적 오류 발생: {}", filePath);
+            throw new IllegalStateException("학생 데이터 파일 처리 실패: " + filePath, e);
         }
     }
 }

--- a/src/main/java/com/ds/dsfest/global/util/IdentityHasher.java
+++ b/src/main/java/com/ds/dsfest/global/util/IdentityHasher.java
@@ -1,0 +1,37 @@
+package com.ds.dsfest.global.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public class IdentityHasher {
+
+    /**
+     *"공백/케이스/노이즈 일관화"
+     */
+    public static String normalize(String s) {
+        if (s == null) return "";
+        return s.trim().replaceAll("\\s+", "").toLowerCase();
+    }
+
+    /**
+     *"학번|이름|신분" 복합키 생성 및 해시
+     */
+    public static String hashIdentity(String studentId, String name, String status) {
+        String combined = normalize(studentId) + "|" + normalize(name) + "|" + normalize(status);
+        return sha256(combined);
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("해시 생성 중 오류 발생", e);
+        }
+    }
+}


### PR DESCRIPTION
- 투표 내역 저장 위한 PhotoVote 필드 수정(StudId->voteKey)
- 관리자용 투표 결과 API 구현

## #️⃣ 연관된 이슈
- close #53 

## 📝 작업 내용
- **PhotoVote 엔티티 수정**: 중복 투표 방지를 위해 해시 기반의 `voterKey`를 도입했습니다.
- **투표 검증 로직**: 1인 3표 제한 및 테마(YOUTH, FESTIVAL, DRESS_CODE) 중복 선택 방지 로직을 구현했습니다.
- **학생 인증 고도화**: 재학생과 휴학생 엑셀 데이터 양식 차이를 분석하여, 두 케이스 모두 정확히 인증할 수 있는 이중 해시 검증 로직을 적용했습니다.

- **테마별 랭킹 API**: 전체 투표 결과를 테마별로 그룹화하고 득표순으로 정렬하여 반환하는 API를 구현했습니다.
- **Swagger 보안 적용**: 관리자 전용 API 호출을 위해 `BearerAuth` 보안 요구사항을 명시했습니다.

## 📌 API 목록
- `POST /api/photo-contest/vote` : 사진 투표하기
- `GET /api/admin/photo-contest/results` : 테마별 실시간 투표 랭킹 조회 (Admin 전용)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 투표 기능 — 학생이 정확히 3개 사진을 선택해 투표 가능(입력 형식 검증 포함)
  * 투표 결과 조회(관리자용) — 테마별 집계된 사진 순위 제공
  * 학생 인증 및 중복 투표 방지 — 인증된 학생만 투표 가능
  * 시작 시 CSV에서 인증 학생을 초기 로드해 초기화하는 배치 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->