### PR TITLE
Feat: 당일 아티스트 조회 API 구현 

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistController.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistController.java
@@ -32,4 +32,10 @@ public class ArtistController implements ArtistControllerDocs {
       @PathVariable Long artistId) {
     return ResponseEntity.ok(ApiResponse.onSuccess(artistService.getArtistPlaylist(artistId)));
   }
+
+  @GetMapping("/today")
+  @Override
+  public ResponseEntity<ApiResponse<List<ArtistListResDto>>> getArtistsByToday() {
+    return ResponseEntity.ok(ApiResponse.onSuccess(artistService.getArtistsByToday()));
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/controller/ArtistControllerDocs.java
@@ -19,4 +19,7 @@ public interface ArtistControllerDocs {
 
   @Operation(summary = "덕우들의 플레이리스트 조회", description = "아티스트의 유튜브 플레이리스트 링크를 조회합니다.")
   ResponseEntity<ApiResponse<ArtistPlaylistResDto>> getArtistPlaylist(Long artistId);
+
+  @Operation(summary = "오늘 아티스트 목록 조회", description = "오늘 날짜 공연 아티스트를 조회합니다.")
+  ResponseEntity<ApiResponse<List<ArtistListResDto>>> getArtistsByToday();
 }

--- a/src/main/java/com/ds/dsfest/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/repository/ArtistRepository.java
@@ -1,13 +1,15 @@
 package com.ds.dsfest.domain.artist.repository;
 
-import java.util.List;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.ds.dsfest.domain.artist.entity.Artist;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
 
   // DAY별 아티스트 조회 (시간순 정렬)
   List<Artist> findByFestivalDayOrderByStartTimeAsc(int festivalDay);
+
+  // 날짜별(오늘) 아티스트 조회 (시간순 정렬)
+  List<Artist> findByPerformanceDateOrderByStartTimeAsc(LocalDate performanceDate);
 }

--- a/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
@@ -1,12 +1,5 @@
 package com.ds.dsfest.domain.artist.service;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.ds.dsfest.domain.artist.dto.ArtistListResDto;
 import com.ds.dsfest.domain.artist.dto.ArtistPlaylistResDto;
 import com.ds.dsfest.domain.artist.entity.Artist;
@@ -14,8 +7,14 @@ import com.ds.dsfest.domain.artist.entity.CountdownStatus;
 import com.ds.dsfest.domain.artist.exception.ArtistErrorCode;
 import com.ds.dsfest.domain.artist.repository.ArtistRepository;
 import com.ds.dsfest.global.exception.CustomException;
-
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class ArtistService {
 
   private final ArtistRepository artistRepository;
+  private final Clock festivalClock;
 
   public List<ArtistListResDto> getArtistsByDay(int day) {
     List<Artist> artists = artistRepository.findByFestivalDayOrderByStartTimeAsc(day);
@@ -45,6 +45,29 @@ public class ArtistService {
                     .build())
         .toList();
   }
+
+    public List<ArtistListResDto> getArtistsByToday() {
+        LocalDate today = LocalDate.now(festivalClock); // 아티스트 공연 날짜가 오늘인 것만 조회
+        List<Artist> artists = artistRepository.findByPerformanceDateOrderByStartTimeAsc(today);
+
+        return artists.stream()
+            .map(
+                artist ->
+                    ArtistListResDto.builder()
+                        .id(artist.getId())
+                        .name(artist.getName())
+                        .shortBio(artist.getShortBio())
+                        .imageUrl(artist.getImageUrl())
+                        .festivalDay(artist.getFestivalDay())
+                        .performanceDate(artist.getPerformanceDate())
+                        .startTime(artist.getStartTime())
+                        .endTime(artist.getEndTime())
+                        .instagramUrl(artist.getInstagramUrl())
+                        .youtubeUrl(artist.getYoutubeUrl())
+                        .countdownStatus(calculateCountdownStatus(artist))
+                        .build())
+            .toList();
+    }
 
   public ArtistPlaylistResDto getArtistPlaylist(Long artistId) {
     Artist artist = getArtistById(artistId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #56 

## 📝 작업 내용
- ArtistRepository 수정: 아티스트 공연 날짜(performanceDate) 기준으로 정렬하여 오늘 날짜에 해당하는 아티스트만 조회하는 findByPerformanceDateOrderByStartTimeAsc(LocalDate) 메서드를 추가했습니다.
- ArtistService 기능 추가: getArtistsByToday() 메서드를 신규 구현하여, Asia/Seoul 기준 오늘 날짜를 가져와 해당 날짜에 출연하는 아티스트 리스트를 반환하도록 하였습니다. 서비스 로직에서는 기존 컨벤션에 맞는 DTO(ArtistListResDto)로 매핑하여 가독성과 유지보수를 강화했습니다.
- ArtistController & ArtistControllerDocs 엔드포인트 추가: /api/artists/today에 대한 GET API 시그니처와 실제 구현을 추가하였습니다. API 응답 타입은 팀 표준에 맞춰 ApiResponse<List<ArtistListResDto>>로 구현하였습니다.
- 테스트 데이터 및 실제 API 검증: 오늘, 과거, 미래 날짜에 아티스트 데이터를 다양하게 삽입하여, 오늘 날짜에만 응답이 잘 반환되는지 API 정상 동작을 확인하였습니다.


### 스크린샷 (선택)
<img width="477" height="486" alt="image" src="https://github.com/user-attachments/assets/177e891f-84b9-4ea4-95b6-a9f117c698ad" />


## 📌 API 목록
`GET  /api/artists/today ` : 오늘 아티스트 조회 

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
