### PR TITLE
Feat: 사용자용 공지 전체 리스트 반환 API 구현 

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -1,18 +1,18 @@
 package com.ds.dsfest.domain.notice.controller;
 
+import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
+import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
+import com.ds.dsfest.domain.notice.service.NoticeService;
+import com.ds.dsfest.global.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
-import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
-import com.ds.dsfest.domain.notice.service.NoticeService;
-import com.ds.dsfest.global.response.ApiResponse;
-
-import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
@@ -21,6 +21,12 @@ import lombok.RequiredArgsConstructor;
 public class NoticeController implements NoticeControllerDocs {
 
   private final NoticeService noticeService;
+
+  @GetMapping
+  @Override
+  public ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList() {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeList()));
+  }
 
   @GetMapping("/urgent")
   public ResponseEntity<ApiResponse<UrgentNoticeResDto>> getUrgentNotice() {

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -1,19 +1,22 @@
 package com.ds.dsfest.domain.notice.controller;
 
-import jakarta.validation.constraints.NotBlank;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-
+import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
 import com.ds.dsfest.global.response.ApiResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Notice", description = "공지사항 사용자 API")
 public interface NoticeControllerDocs {
+  @Operation(
+      summary = "공지 전체 목록 조회",
+      description = "최신순 공지 전체 리스트를 반환합니다.")
+  ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList();
 
   @Operation(
       summary = "긴급공지 조회",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #
## 📝 작업 내용
- NoticeController, NoticeControllerDocs에 GET /api/notices 명세 및 구현 추가
- NoticeService의 getNoticeList() 로직 활용하여 최신순 전체 공지 반환
- NoticeListItemResDto로 응답, ApiResponse<List> 형태 적용

### 스크린샷 (선택)
<img width="421" height="574" alt="image" src="https://github.com/user-attachments/assets/d242c505-3e27-4ab0-a8f7-439f030e3628" />


## 📌 API 목록
`GET /api/notices` : 전체 공지 리스트 반환

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- `CodeRabbit 생성 주석 삭제 후 main reset -> 다시 PR 생성 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공지사항 목록 조회 API 엔드포인트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->