### PR TITLE
Feat: category별 공지 리스트 조회

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.notice.controller;
 
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -26,6 +27,14 @@ public class NoticeController implements NoticeControllerDocs {
   @Override
   public ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList() {
     return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeList()));
+  }
+
+  @GetMapping("/category")
+  @Override
+  public ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticesByCategory(
+      @RequestParam NoticeCategory category
+  ) {
+     return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeListByCategory(category)));
   }
 
   @GetMapping("/urgent")

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -1,5 +1,6 @@
 package com.ds.dsfest.domain.notice.controller;
 
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -17,6 +18,14 @@ public interface NoticeControllerDocs {
       summary = "공지 전체 목록 조회",
       description = "최신순 공지 전체 리스트를 반환합니다.")
   ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticeList();
+
+  @Operation(
+      summary = "카테고리별 공지 목록 조회",
+      description = "공지 카테고리로 필터링된 리스트를 최신순으로 반환합니다."
+  )
+  ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticesByCategory(
+     @RequestParam NoticeCategory category
+  );
 
   @Operation(
       summary = "긴급공지 조회",

--- a/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
@@ -1,18 +1,18 @@
 package com.ds.dsfest.domain.notice.repository;
 
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.entity.Notice;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.ds.dsfest.domain.notice.entity.Notice;
-
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
   List<Notice> findAllByOrderByCreatedAtDesc();
+  List<Notice> findAllByCategoryOrderByCreatedAtDesc(NoticeCategory category);
 
   Optional<Notice> findTopByUrgentTrueOrderByCreatedAtDesc();
 

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -1,15 +1,6 @@
 package com.ds.dsfest.domain.notice.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
+import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
 import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
@@ -21,8 +12,15 @@ import com.ds.dsfest.domain.notice.exception.NoticeErrorCode;
 import com.ds.dsfest.domain.notice.repository.NoticeRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.infra.s3.S3Uploader;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +47,13 @@ public class NoticeService {
   @Transactional(readOnly = true)
   public List<NoticeListItemResDto> getNoticeList() {
     return noticeRepository.findAllByOrderByCreatedAtDesc().stream()
+        .map(NoticeListItemResDto::from)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<NoticeListItemResDto> getNoticeListByCategory(NoticeCategory category) {
+    return noticeRepository.findAllByCategoryOrderByCreatedAtDesc(category).stream()
         .map(NoticeListItemResDto::from)
         .toList();
   }

--- a/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ds/dsfest/global/exception/GlobalExceptionHandler.java
@@ -1,20 +1,17 @@
 package com.ds.dsfest.global.exception;
 
-import java.util.stream.Collectors;
-
+import com.ds.dsfest.global.response.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
-
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-
-import com.ds.dsfest.global.response.ApiResponse;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -56,6 +53,16 @@ public class GlobalExceptionHandler {
     log.warn("ConstraintViolationException: {}", errorMessage);
     return ResponseEntity.status(GlobalErrorCode.INVALID_INPUT.getStatus())
         .body(ApiResponse.onFailure(GlobalErrorCode.INVALID_INPUT, errorMessage));
+  }
+  /**
+   * enum 변환 등 parameter 타입 변환 실패시
+   * (ex. category=UNKNOWN 처럼 enum 바인딩 실패)
+   */
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+      log.warn("MethodArgumentTypeMismatchException: {}", e.getMessage());
+      return ResponseEntity.status(GlobalErrorCode.INVALID_INPUT.getStatus())
+          .body(ApiResponse.onFailure(GlobalErrorCode.INVALID_INPUT, "잘못된 입력 값입니다: " + e.getValue()));
   }
 
   /** 존재하지 않는 경로 (favicon.ico 등 브라우저 기본 요청 포함) */


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #60 

## 📝 작업 내용
- NoticeRepository에 findAllByCategoryOrderByCreatedAtDesc(NoticeCategory category) 메서드 추가
- NoticeService에 카테고리 필터 리스트 조회 기능(getNoticeListByCategory) 구현
- NoticeControllerDocs에 카테고리별 목록 조회 API 시그니처 명세 추가
- NoticeController에 GET /api/notices/category 엔드포인트 구현
- 카테고리별 공지 필터링 및 응답 검증 완료

### 스크린샷 (선택)
<img width="466" height="794" alt="image" src="https://github.com/user-attachments/assets/476af5e7-a6b6-423c-a01f-63ed8ab0b790" />

## 📌 API 목록
`GET /api/notices/category` : 카테고리별 공지 최신순 리스트 반환

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지사항을 카테고리별로 필터링하여 조회할 수 있는 API가 추가되었습니다. 선택한 카테고리의 공지사항을 최신순으로 확인할 수 있습니다.
* **문서**
  * 카테고리별 공지 조회 엔드포인트에 대한 API 문서가 추가/갱신되었습니다.
* **버그 수정**
  * 잘못된 요청 파라미터(예: 잘못된 enum 값) 처리 시 명확한 에러 응답을 반환하도록 오류 핸들링이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->