### PR TITLE
Feat: 공지 상세 조회 구현

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -1,6 +1,7 @@
 package com.ds.dsfest.domain.notice.controller;
 
 import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +37,12 @@ public class NoticeController implements NoticeControllerDocs {
       @RequestParam NoticeCategory category
   ) {
      return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeListByCategory(category)));
+  }
+
+  @GetMapping("/{noticeId}")
+  @Override
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVariable Long noticeId) {
+      return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetail(noticeId)));
   }
 
   @GetMapping("/urgent")

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -1,6 +1,7 @@
 package com.ds.dsfest.domain.notice.controller;
 
 import com.ds.dsfest.domain.notice.constant.NoticeCategory;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeListItemResDto;
 import com.ds.dsfest.domain.notice.dto.NoticeSearchResDto;
 import com.ds.dsfest.domain.notice.dto.UrgentNoticeResDto;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Notice", description = "공지사항 사용자 API")
@@ -26,6 +28,12 @@ public interface NoticeControllerDocs {
   ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getNoticesByCategory(
      @RequestParam NoticeCategory category
   );
+
+  @Operation(
+      summary = "공지 상세 조회",
+      description = "공지 id로 상세 정보(사진 포함) 반환"
+  )
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVariable Long noticeId);
 
   @Operation(
       summary = "긴급공지 조회",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #63 

## 📝 작업 내용
- NoticeControllerDocs에 공지 상세 조회 API 명세 추가
- NoticeController에 공지 상세 조회 GET /api/notices/{noticeId} 엔드포인트 구현
- NoticeService의 getNoticeDetail 메서드 활용
- 공지 상세 응답에 이미지 URL 리스트 포함
- 어드민 API로 이미지 등록 후 상세 조회 시 이미지 정상 반환 확인
- Swagger 문서에 상세 조회 예시 및 설명 추가

### 스크린샷 (선택)
<img width="734" height="780" alt="image" src="https://github.com/user-attachments/assets/eef6bffc-b45e-40a9-86a2-f54e00a6e872" />

## 📌 API 목록
`GET /api/notices/{noticeId}` : 공지 상세 조회 (사진 포함) 

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 공지사항의 상세 정보를 조회할 수 있는 새로운 API 엔드포인트 추가
- 특정 공지사항의 세부 내용과 첨부 사진을 함께 조회하는 기능 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->