### PR TITLE
Feat: 자주 찾는 공지 기능 API 구현

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
@@ -49,7 +49,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
   @GetMapping("/{noticeId}")
   public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(
       @PathVariable Long noticeId) {
-    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetailWithViewCount(noticeId)));
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetail(noticeId)));
   }
 
   @PutMapping(value = "/{noticeId}", consumes = "multipart/form-data")

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/AdminNoticeController.java
@@ -49,7 +49,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
   @GetMapping("/{noticeId}")
   public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(
       @PathVariable Long noticeId) {
-    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetail(noticeId)));
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetailWithViewCount(noticeId)));
   }
 
   @PutMapping(value = "/{noticeId}", consumes = "multipart/form-data")

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -55,4 +55,10 @@ public class NoticeController implements NoticeControllerDocs {
       @RequestParam String keyword) {
     return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.searchNotices(keyword)));
   }
+
+  @GetMapping("/frequent")
+  @Override
+  public ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getFrequentNotices() {
+      return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getFrequentNoticeList()));
+  }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -41,8 +41,8 @@ public class NoticeController implements NoticeControllerDocs {
 
   @GetMapping("/{noticeId}")
   @Override
-  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVariable Long noticeId) {
-      return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetail(noticeId)));
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVaable Long noticeId) {
+      return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetailWithViewCount(noticeId)));
   }
 
   @GetMapping("/urgent")

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeController.java
@@ -41,7 +41,7 @@ public class NoticeController implements NoticeControllerDocs {
 
   @GetMapping("/{noticeId}")
   @Override
-  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVaable Long noticeId) {
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> getNoticeDetail(@PathVariable Long noticeId) {
       return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.getNoticeDetailWithViewCount(noticeId)));
   }
 

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -45,4 +45,10 @@ public interface NoticeControllerDocs {
       description = "keyword로 제목·본문을 검색합니다. 결과가 없으면 results는 빈 배열, recommended에 조회수 상위 3개가 담깁니다.")
   ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
       @RequestParam @NotBlank String keyword);
+
+  @Operation(
+      summary = "자주 찾는 공지 조회",
+      description = "조회수 상위 4개의 공지사항 목록을 반환합니다."
+  )
+  ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getFrequentNotices();
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeDetailResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeDetailResDto.java
@@ -14,7 +14,8 @@ public record NoticeDetailResDto(
     String content,
     List<String> imageUrls,
     LocalDateTime createdAt,
-    LocalDateTime updatedAt) {
+    LocalDateTime updatedAt,
+    int viewCount) {
 
   public static NoticeDetailResDto from(Notice notice) {
     List<String> imageUrls = notice.getImages().stream().map(image -> image.getImageUrl()).toList();
@@ -26,6 +27,8 @@ public record NoticeDetailResDto(
         notice.getContent(),
         imageUrls,
         notice.getCreatedAt(),
-        notice.getUpdatedAt());
+        notice.getUpdatedAt(),
+        notice.getViewCount()
+    );
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeListItemResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/dto/NoticeListItemResDto.java
@@ -6,7 +6,7 @@ import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.entity.Notice;
 
 public record NoticeListItemResDto(
-    Long id, String title, NoticeCategory category, boolean urgent, LocalDateTime createdAt) {
+    Long id, String title, NoticeCategory category, boolean urgent, LocalDateTime createdAt, int viewCount) {
 
   public static NoticeListItemResDto from(Notice notice) {
     return new NoticeListItemResDto(
@@ -14,6 +14,8 @@ public record NoticeListItemResDto(
         notice.getTitle(),
         notice.getCategory(),
         notice.isUrgent(),
-        notice.getCreatedAt());
+        notice.getCreatedAt(),
+        notice.getViewCount()
+    );
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
@@ -20,7 +20,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
       "SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdAt DESC")
   List<Notice> searchByKeyword(@Param("keyword") String keyword);
 
-  List<Notice> findTop4ByOrderByViewCountDesc();
+  List<Notice> findTop4ByOrderByViewCountDescCreatedAtDesc();
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")

--- a/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
@@ -20,7 +20,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
       "SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdAt DESC")
   List<Notice> searchByKeyword(@Param("keyword") String keyword);
 
-  List<Notice> findTop3ByOrderByViewCountDesc();
+  List<Notice> findTop4ByOrderByViewCountDesc();
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -99,7 +99,7 @@ public class NoticeService {
 
     List<NoticeListItemResDto> recommended =
         results.isEmpty()
-            ? noticeRepository.findTop4ByOrderByViewCountDesc().stream()
+            ? noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc().stream()
                 .map(NoticeListItemResDto::from)
                 .toList()
             : List.of();
@@ -157,7 +157,7 @@ public class NoticeService {
 
    @Transactional(readOnly = true)
    public List<NoticeListItemResDto> getFrequentNoticeList() {
-      return noticeRepository.findTop4ByOrderByViewCountDesc().stream()
+      return noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc().stream()
           .map(NoticeListItemResDto::from)
           .toList();
   }

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -99,7 +99,7 @@ public class NoticeService {
 
     List<NoticeListItemResDto> recommended =
         results.isEmpty()
-            ? noticeRepository.findTop3ByOrderByViewCountDesc().stream()
+            ? noticeRepository.findTop4ByOrderByViewCountDesc().stream()
                 .map(NoticeListItemResDto::from)
                 .toList()
             : List.of();
@@ -153,5 +153,12 @@ public class NoticeService {
     return noticeRepository
         .findById(noticeId)
         .orElseThrow(() -> new CustomException(NoticeErrorCode.NOTICE_NOT_FOUND));
+  }
+
+   @Transactional(readOnly = true)
+   public List<NoticeListItemResDto> getFrequentNoticeList() {
+      return noticeRepository.findTop4ByOrderByViewCountDesc().stream()
+          .map(NoticeListItemResDto::from)
+          .toList();
   }
 }

--- a/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
@@ -155,7 +155,7 @@ class NoticeServiceTest {
   void searchNotices_empty_returnsRecommended() {
     Notice recommended = Notice.create("자주 찾는 공지", "내용", NoticeCategory.ETC, false);
     when(noticeRepository.searchByKeyword("없는키워드")).thenReturn(List.of());
-    when(noticeRepository.findTop4ByOrderByViewCountDesc()).thenReturn(List.of(recommended));
+    when(noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc()).thenReturn(List.of(recommended));
 
     NoticeSearchResDto result = noticeService.searchNotices("없는키워드");
 
@@ -174,7 +174,7 @@ class NoticeServiceTest {
 
     assertThat(result.results()).hasSize(1);
     assertThat(result.recommended()).isEmpty();
-    verify(noticeRepository, never()).findTop4ByOrderByViewCountDesc();
+    verify(noticeRepository, never()).findTop4ByOrderByViewCountDescCreatedAtDesc();
   }
 
   @Test

--- a/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
@@ -1,27 +1,5 @@
 package com.ds.dsfest.domain.notice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
 import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
@@ -33,6 +11,22 @@ import com.ds.dsfest.domain.notice.exception.NoticeErrorCode;
 import com.ds.dsfest.domain.notice.repository.NoticeRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.infra.s3.S3Uploader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class NoticeServiceTest {
@@ -161,7 +155,7 @@ class NoticeServiceTest {
   void searchNotices_empty_returnsRecommended() {
     Notice recommended = Notice.create("자주 찾는 공지", "내용", NoticeCategory.ETC, false);
     when(noticeRepository.searchByKeyword("없는키워드")).thenReturn(List.of());
-    when(noticeRepository.findTop3ByOrderByViewCountDesc()).thenReturn(List.of(recommended));
+    when(noticeRepository.findTop4ByOrderByViewCountDesc()).thenReturn(List.of(recommended));
 
     NoticeSearchResDto result = noticeService.searchNotices("없는키워드");
 
@@ -180,7 +174,7 @@ class NoticeServiceTest {
 
     assertThat(result.results()).hasSize(1);
     assertThat(result.recommended()).isEmpty();
-    verify(noticeRepository, never()).findTop3ByOrderByViewCountDesc();
+    verify(noticeRepository, never()).findTop4ByOrderByViewCountDesc();
   }
 
   @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #65 

## 📝 작업 내용
- Notice 조회수(viewCount) 필드 NoticeListItemResDto, NoticeDetailResDto에 추가
- 공지 상세 조회 시 viewCount 1 증가하도록 서비스/컨트롤러 로직 개선
- NoticeRepository에 조회수 내림차순 상위 4개 반환 쿼리 메서드 추가(findTop4ByOrderByViewCountDesc)
- 자주 찾는 공지 리스트 API(/api/notices/frequent) 컨트롤러·Docs·서비스 구현
- @Modifying 등 JPA 어노테이션 누락 부분 보강
- 관련 엔드포인트(Swagger)에서 정상 동작 및 응답값 검증

### 스크린샷 (선택)
<img width="370" height="589" alt="image" src="https://github.com/user-attachments/assets/f5e31956-5495-4d17-b428-1aa3a7ce1e5b" />

## 📌 API 목록
GET /api/notices/frequent : 자주 찾는 공지 (조회수 높은 순서) 4개 반환

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- 사용자가 공지를 클릭했을 때 조회수 +1 
- 조회수가 높은 순서대로 자주 찾는 공지 4개 반환 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자주 조회된 공지사항을 확인할 수 있는 신규 엔드포인트 추가 (조회수 상위 4개)

* **개선 사항**
  * 공지사항 상세 조회에 조회수 정보 포함
  * 공지사항 목록 항목에 조회수 노출

* **문서**
  * API 문서에 자주 조회된 공지사항 조회 엔드포인트 명세 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->