### PR TITLE
Fix: PhotoVote 엔티티 voterKey 유니크 제약 조건 제거

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoParticipation.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoParticipation.java
@@ -1,0 +1,25 @@
+package com.ds.dsfest.domain.photocontest.entity;
+
+import com.ds.dsfest.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "photo_participations")
+public class PhotoParticipation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String voterKey;
+
+    public PhotoParticipation(String voterKey) {
+        this.voterKey = voterKey;
+    }
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/entity/PhotoVote.java
@@ -20,7 +20,7 @@ public class PhotoVote extends BaseEntity {
   @JoinColumn(name = "photo_entry_id", nullable = false)
   private PhotoEntry photoEntry;
 
-  @Column(nullable = false, length = 64, unique = true)
+  @Column(nullable = false, length = 64)
   private String voterKey;
 
   public PhotoVote(PhotoEntry photoEntry, String voterKey) {

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoEntryRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface PhotoEntryRepository extends JpaRepository<PhotoEntry, Long> {
     /**
-     * 모든 출품작을 생성 순으로 조회합니다.
+     * 모든 출품작을 ID 순으로 조회합니다.
      */
-    List<PhotoEntry> findAllByOrderByCreatedAtDesc();
+    List<PhotoEntry> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoParticipationRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/repository/PhotoParticipationRepository.java
@@ -1,0 +1,8 @@
+package com.ds.dsfest.domain.photocontest.repository;
+
+import com.ds.dsfest.domain.photocontest.entity.PhotoParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoParticipationRepository extends JpaRepository<PhotoParticipation, Long> {
+    boolean existsByVoterKey(String voterKey);
+}

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -5,15 +5,14 @@ import com.ds.dsfest.domain.photocontest.constant.PhotoTheme;
 import com.ds.dsfest.domain.photocontest.dto.*;
 import com.ds.dsfest.domain.photocontest.entity.PhotoContestSetting;
 import com.ds.dsfest.domain.photocontest.entity.PhotoEntry;
+import com.ds.dsfest.domain.photocontest.entity.PhotoParticipation;
 import com.ds.dsfest.domain.photocontest.entity.PhotoVote;
-import com.ds.dsfest.domain.photocontest.repository.PhotoContestSettingRepository;
-import com.ds.dsfest.domain.photocontest.repository.PhotoEntryRepository;
-import com.ds.dsfest.domain.photocontest.repository.PhotoVoteRepository;
-import com.ds.dsfest.domain.photocontest.repository.VerifiedStudentRepository;
+import com.ds.dsfest.domain.photocontest.repository.*;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.exception.GlobalErrorCode;
 import com.ds.dsfest.global.util.IdentityHasher;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +30,7 @@ public class PhotoContestService {
     private final PhotoEntryRepository photoEntryRepository;
     private final PhotoVoteRepository photoVoteRepository;
     private final VerifiedStudentRepository verifiedStudentRepository;
+    private final PhotoParticipationRepository photoParticipationRepository;
 
     /**
      * 사진 콘테스트의 현재 상태 및 마감 시간을 반환합니다.
@@ -142,6 +142,16 @@ public class PhotoContestService {
         long themeCount = selectedPhotos.stream().map(PhotoEntry::getTheme).distinct().count();
         if (themeCount != 3) {
             throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+
+        /**
+         * 동시성 이슈 방어
+         */
+        try {
+            photoParticipationRepository.save(new PhotoParticipation(voterKey));
+            photoParticipationRepository.flush(); // 즉시 DB에 쏴서 충돌 여부 확인
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST); // 늦게 들어온 요청은 여기서 튕김!
         }
 
         /**

--- a/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
+++ b/src/main/java/com/ds/dsfest/domain/photocontest/service/PhotoContestService.java
@@ -81,7 +81,7 @@ public class PhotoContestService {
      * 사진 콘테스트 출품작 목록을 주제별로 분류하여 전체 조회합니다.
      */
     public PhotoListResDto getPhotoList() {
-        List<PhotoEntry> allPhotos = photoEntryRepository.findAllByOrderByCreatedAtDesc();
+        List<PhotoEntry> allPhotos = photoEntryRepository.findAllByOrderByIdAsc();
 
         List<PhotoListResDto.PhotoSummaryDto> youthPhotos = allPhotos.stream()
             .filter(photo -> photo.getTheme() == PhotoTheme.YOUTH)


### PR DESCRIPTION
- 한 명의 사용자가 주제별로 3표를 투표할ì 수 있도록 voterKey의 unique 설정 제거

## #️⃣ 연관된 이슈
- close #53 

## 📝 작업 내용
- 사진 콘테스트 투표 API에서 발생하는 **500 Internal Server Error**를 해결했습니다.

### 🔍 원인 분석
- `PhotoVote` 엔티티의 `voterKey`에 `unique = true`가 설정되어 있어, 한 명의 사용자가 3표를 던질 때(3개의 Row 생성 시) 두 번째 데이터부터 DB 유니크 제약 조건 위반 에러가 발생했습니다.

### 🛠️ 해결 방법
- `PhotoVote` 엔티티에서 `unique = true` 옵션을 삭제했습니다.
- 중복 투표 방지는 이미 서비스 로직의 `existsByVoterKey`를 통해 검증하고 있으므로 DB 레벨의 제약은 불필요하다고 판단했습니다.

## 📌 API 목록
- `POST /api/photo-contest/vote` 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사진 목록 정렬 방식이 변경되어 항목 표시 순서가 달라졌습니다.
  * 투표 처리 흐름이 변경되어 투표 시점의 데이터 저장/검증이 강화되었습니다.
  * 투표자 식별자의 중복 제약이 데이터 레벨에서 조정되었습니다.

* **기타**
  * 플랫폼 안정성 강화를 위한 내부 데이터 처리 로직이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->