### PR TITLE
Feat: 대화 주제 제목 구분

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkController.java
@@ -16,17 +16,20 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/livetalk")
-public class LiveTalkController {
+public class LiveTalkController implements LiveTalkControllerDocs {
 
   private final LiveTalkService liveTalkService;
+  private final ChatTopicService chatTopicService;
 
   // 메시지 목록
+  @Override
   @GetMapping("/messages")
   public ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getRecentMessages() {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getRecentMessages()));
   }
 
   // 이전 메시지
+  @Override
   @GetMapping("/messages/before")
   public ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getMessagesBefore(
       @RequestParam Long messageId) {
@@ -34,6 +37,7 @@ public class LiveTalkController {
   }
 
   // 읽음 처리
+  @Override
   @PatchMapping("/read")
   public ResponseEntity<ApiResponse<Void>> markAsRead(@RequestParam String guestUuid) {
     liveTalkService.markAsRead(guestUuid);
@@ -41,14 +45,14 @@ public class LiveTalkController {
   }
 
   // 안 읽은 메시지 수
+  @Override
   @GetMapping("/unread-count")
   public ResponseEntity<ApiResponse<Long>> getUnreadCount(@RequestParam String guestUuid) {
     return ResponseEntity.ok(ApiResponse.onSuccess(liveTalkService.getUnreadCount(guestUuid)));
   }
 
-  private final ChatTopicService chatTopicService;
-
   // 대화 주제
+  @Override
   @GetMapping("/topics/current")
   public ResponseEntity<ApiResponse<ChatTopicResDto>> getCurrentTopic() {
     return ResponseEntity.ok(ApiResponse.onSuccess(chatTopicService.getCurrentTopic()));

--- a/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/controller/LiveTalkControllerDocs.java
@@ -1,0 +1,31 @@
+package com.ds.dsfest.domain.livetalk.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.ds.dsfest.domain.livetalk.dto.ChatMessageResDto;
+import com.ds.dsfest.domain.livetalk.dto.ChatTopicResDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "LiveTalk", description = "라이브톡 관련 API")
+public interface LiveTalkControllerDocs {
+
+  @Operation(summary = "최근 메시지 목록 조회", description = "라이브톡의 최근 메시지 목록을 조회합니다.")
+  ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getRecentMessages();
+
+  @Operation(summary = "이전 메시지 조회", description = "messageId를 기준으로 해당 메시지보다 이전에 작성된 메시지 목록을 조회합니다.")
+  ResponseEntity<ApiResponse<List<ChatMessageResDto>>> getMessagesBefore(Long messageId);
+
+  @Operation(summary = "읽음 처리", description = "guestUuid 기준으로 라이브톡 메시지를 읽음 처리합니다.")
+  ResponseEntity<ApiResponse<Void>> markAsRead(String guestUuid);
+
+  @Operation(summary = "안 읽은 메시지 수 조회", description = "guestUuid 기준으로 아직 읽지 않은 라이브톡 메시지 수를 조회합니다.")
+  ResponseEntity<ApiResponse<Long>> getUnreadCount(String guestUuid);
+
+  @Operation(summary = "현재 대화 주제 조회", description = "현재 시각 기준으로 진행 중인 라이브톡 대화 주제를 조회합니다.")
+  ResponseEntity<ApiResponse<ChatTopicResDto>> getCurrentTopic();
+}

--- a/src/main/java/com/ds/dsfest/domain/livetalk/dto/ChatTopicResDto.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/dto/ChatTopicResDto.java
@@ -1,17 +1,17 @@
 package com.ds.dsfest.domain.livetalk.dto;
 
+import com.ds.dsfest.domain.livetalk.constant.ChatTopicType;
 import com.ds.dsfest.domain.livetalk.entity.ChatTopic;
 
 public record ChatTopicResDto(
-    Long id,
-    String content,
-    com.ds.dsfest.domain.livetalk.constant.ChatTopicType topicType,
-    Long artistId) {
-  public static ChatTopicResDto from(ChatTopic chatTopic) {
+    Long id, String title, String subtitle, ChatTopicType topicType, Long artistId) {
+
+  public static ChatTopicResDto from(ChatTopic topic) {
     return new ChatTopicResDto(
-        chatTopic.getId(),
-        chatTopic.getContent(),
-        chatTopic.getTopicType(),
-        chatTopic.getArtist() != null ? chatTopic.getArtist().getId() : null);
+        topic.getId(),
+        topic.getTitle(),
+        topic.getSubtitle(),
+        topic.getTopicType(),
+        topic.getArtist() != null ? topic.getArtist().getId() : null);
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/entity/ChatTopic.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/entity/ChatTopic.java
@@ -32,8 +32,11 @@ public class ChatTopic extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = true, length = 255)
+  private String subtitle; // 서브 문구 (소제목)
+
   @Column(nullable = false, length = 255)
-  private String content;
+  private String title; // 메인 문구 (대제목)
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 10)
@@ -46,6 +49,6 @@ public class ChatTopic extends BaseEntity {
   private LocalDateTime endTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "artist_id")
+  @JoinColumn(name = "artist_id", nullable = true)
   private Artist artist;
 }

--- a/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
+++ b/src/main/java/com/ds/dsfest/domain/livetalk/service/LiveTalkService.java
@@ -1,9 +1,10 @@
 package com.ds.dsfest.domain.livetalk.service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.Comparator;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) close #71 

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
대화 주제 제목 구분
livetalk 스웨거 문서 작성

### 스크린샷 (선택)

## 📌 API 목록

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 라이브 토크 API 엔드포인트에 대한 Swagger/OpenAPI 문서가 추가되었습니다.

* **Refactor**
  * 채팅 주제 정보 구조가 개선되어 제목과 부제목이 명확하게 구분됩니다.
  * 컨트롤러 구현이 재구성되어 API 인터페이스 표준이 적용되었습니다.

* **Chores**
  * 내부 코드 정리가 수행되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->