### PR TITLE
Fix: 부스 이미지 데이터값 수정

### DIFF
--- a/scripts/drive_files.tsv
+++ b/scripts/drive_files.tsv
@@ -91,7 +91,7 @@ file_id	filename
 1GTqO61HGLlzOIEX9MFTbvGYEnsb9VPrs	62-1. 도봉또봄.jpeg
 1hMUw5WC2zyNcZEqGDzvvnUuoJbAxR1Y7	62-2. 도봉또봄.jpeg
 1yrQ3cPGauU49fe5ov-mWlSc4DnF13Gpz	64. 룡하다! 공룡타로.png
-1hafINnz59xu_nzLl_zyhs_Uk6ghp1tyt	66. 35mm Archive.JPG
+1bulotBVMkBEQVXkImWp39ZiOsmoJfCzG	66. 35mm Archive.JPG
 1RfqP_1kpy9nnN1cXZdTPmB819BTS6fiE	67-1. 한 코, 한 땀.jpeg
 1YWRiwkgurs9WrHkT9VSqAhzuB7hZZAFy	67-2. 한 코, 한 땀.jpeg
 1Rp8OyZiulUoCiMcntCjxcsDere6SmYed	67-3. 한 코, 한 땀.jpeg

--- a/scripts/generate_booth_images_seed.py
+++ b/scripts/generate_booth_images_seed.py
@@ -18,7 +18,7 @@ OUT_PATH = ROOT / "src" / "main" / "resources" / "db" / "booth-images-seed.sql"
 
 # 운영진이 사진을 수정/재업로드 중인 부스 — INSERT 라인을 주석으로 출력.
 # 작업 끝나면 set에서 제거 후 재실행.
-SKIP_BOOTH_IDS: set[int] = {66}
+SKIP_BOOTH_IDS: set[int] = set()
 
 # "{boothNumber}-{order}. " 또는 "{boothNumber}. " (뒤 공백 없는 케이스도)
 FILENAME_RE = re.compile(r"^(\d+)(?:-(\d+))?\.\s*")

--- a/src/main/resources/db/booth-images-seed.sql
+++ b/src/main/resources/db/booth-images-seed.sql
@@ -103,8 +103,7 @@ INSERT INTO booth_images (booth_id, image_order, image_url) VALUES
   (62, 1, 'https://lh3.googleusercontent.com/d/1GTqO61HGLlzOIEX9MFTbvGYEnsb9VPrs=w1200'),  -- 62-1. 도봉또봄.jpeg
   (62, 2, 'https://lh3.googleusercontent.com/d/1hMUw5WC2zyNcZEqGDzvvnUuoJbAxR1Y7=w1200'),  -- 62-2. 도봉또봄.jpeg
   (64, 1, 'https://lh3.googleusercontent.com/d/1yrQ3cPGauU49fe5ov-mWlSc4DnF13Gpz=w1200'),  -- 64. 룡하다! 공룡타로.png
-  -- TODO: 운영진 작업 대기 (skip list) — 끝나면 SKIP_BOOTH_IDS에서 제거 후 재실행
-  -- (66, 1, 'https://lh3.googleusercontent.com/d/1hafINnz59xu_nzLl_zyhs_Uk6ghp1tyt=w1200'),  -- 66. 35mm Archive.JPG
+  (66, 1, 'https://lh3.googleusercontent.com/d/1bulotBVMkBEQVXkImWp39ZiOsmoJfCzG=w1200'),  -- 66. 35mm Archive.JPG(수정)
   (67, 1, 'https://lh3.googleusercontent.com/d/1RfqP_1kpy9nnN1cXZdTPmB819BTS6fiE=w1200'),  -- 67-1. 한 코, 한 땀.jpeg
   (67, 2, 'https://lh3.googleusercontent.com/d/1YWRiwkgurs9WrHkT9VSqAhzuB7hZZAFy=w1200'),  -- 67-2. 한 코, 한 땀.jpeg
   (67, 3, 'https://lh3.googleusercontent.com/d/1Rp8OyZiulUoCiMcntCjxcsDere6SmYed=w1200'),  -- 67-3. 한 코, 한 땀.jpeg


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #75 

## 📝 작업 내용
- 66번 부스 이미지 수정 위해 스크립트 실행 및 편집

### 스크린샷 (선택)

## 📌 API 목록

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 부스 66의 이미지가 정상적으로 데이터베이스에 입력되었습니다. 부스 정보 페이지에서 부스 66의 이미지를 확인할 수 있으며, 이미지 URL이 최신화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->