### PR TITLE
Feat: 인증 없는 공지사항 작성·수정 테스트 API 추가

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
@@ -75,7 +75,7 @@ public class ArtistService {
 
   // 공연 상태 계산
   private CountdownStatus calculateCountdownStatus(Artist artist) {
-      LocalDateTime now = LocalDateTime.now(festivalClock);
+    LocalDateTime now = LocalDateTime.now(festivalClock);
 
     LocalDateTime start = LocalDateTime.of(artist.getPerformanceDate(), artist.getStartTime());
     LocalDateTime end = LocalDateTime.of(artist.getPerformanceDate(), artist.getEndTime());

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeController.java
@@ -1,0 +1,49 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.domain.notice.service.NoticeService;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/notices")
+public class TestNoticeController implements TestNoticeControllerDocs {
+
+  private final NoticeService noticeService;
+
+  @PostMapping(consumes = "multipart/form-data")
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> createNotice(
+      @RequestPart("data") @Valid NoticeCreateReqDto req,
+      @RequestPart(value = "images", required = false) List<MultipartFile> images)
+      throws IOException {
+    return ResponseEntity.ok(ApiResponse.onSuccess(noticeService.createNotice(req, images)));
+  }
+
+  @PutMapping(value = "/{noticeId}", consumes = "multipart/form-data")
+  public ResponseEntity<ApiResponse<NoticeDetailResDto>> updateNotice(
+      @PathVariable Long noticeId,
+      @RequestPart("data") @Valid NoticeUpdateReqDto req,
+      @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages)
+      throws IOException {
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(noticeService.updateNotice(noticeId, req, newImages)));
+  }
+}

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeControllerDocs.java
@@ -1,0 +1,58 @@
+package com.ds.dsfest.domain.notice.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
+import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
+import com.ds.dsfest.domain.notice.dto.NoticeUpdateReqDto;
+import com.ds.dsfest.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Test Notice", description = "인증 없이 공지사항 작성·수정 테스트용 API (로그인 불필요)")
+public interface TestNoticeControllerDocs {
+
+  @Operation(
+      summary = "[TEST] 공지 작성",
+      description =
+          "로그인 없이 공지사항을 작성합니다. 테스트 API입니다.\n\n"
+              + "**category** 가능한 값\n"
+              + "- `EVENT` : 이벤트\n"
+              + "- `PERFORMANCE` : 공연\n"
+              + "- `ETC` : 기타\n"
+              + "- `NOTICE` : 안내")
+  @RequestBody(
+      content =
+          @Content(
+              mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+              encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> createNotice(
+      NoticeCreateReqDto req, List<MultipartFile> images) throws IOException;
+
+  @Operation(
+      summary = "[TEST] 공지 수정",
+      description =
+          "로그인 없이 공지사항을 수정합니다. 테스트 API입니다.\n\n"
+              + "keepImageUrls에 유지할 기존 이미지 URL을 순서대로 담아 전송하세요. 포함되지 않은 기존 이미지는 S3에서 삭제됩니다.\n\n"
+              + "**category** 가능한 값\n"
+              + "- `EVENT` : 이벤트\n"
+              + "- `PERFORMANCE` : 공연\n"
+              + "- `ETC` : 기타\n"
+              + "- `NOTICE` : 안내")
+  @RequestBody(
+      content =
+          @Content(
+              mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+              encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
+  ResponseEntity<ApiResponse<NoticeDetailResDto>> updateNotice(
+      Long noticeId, NoticeUpdateReqDto req, List<MultipartFile> newImages) throws IOException;
+}

--- a/src/main/java/com/ds/dsfest/global/config/SecurityConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/SecurityConfig.java
@@ -39,9 +39,7 @@ public class SecurityConfig {
     http.csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .headers(headers ->
-            headers.frameOptions(frame -> frame.sameOrigin())
-        )
+        .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .cors(cors -> cors.configurationSource(corsConfigurationSource))

--- a/src/main/java/com/ds/dsfest/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/WebSocketConfig.java
@@ -21,11 +21,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     // WebSocket 연결 엔드포인트 (SockJS 폴백 포함)
-    registry.addEndpoint("/ws").setAllowedOriginPatterns(
-        "http://localhost:5173",
-        "http://localhost:3000",
-        "https://youth-of-duksung.site",
-        "https://www.youth-of-duksung.site"
-    ).withSockJS();
+    registry
+        .addEndpoint("/ws")
+        .setAllowedOriginPatterns(
+            "http://localhost:5173",
+            "http://localhost:3000",
+            "https://youth-of-duksung.site",
+            "https://www.youth-of-duksung.site")
+        .withSockJS();
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#82 

## 📝 작업 내용
- 어드민 로그인 없이 공지사항을 작성·수정할 수 있는 테스트 전용 API 2개 추가
- 기존 NoticeService 로직 그대로 재사용

## 📌 API 목록
- POST /api/test/notices — 공지 작성
- PUT /api/test/notices/{noticeId} — 공지 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 공지 사항 생성 및 수정 시 이미지 업로드 기능 추가 - 공지를 작성할 때 텍스트 정보와 함께 여러 이미지를 파일 형식으로 업로드할 수 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->