### PR TITLE
Feat: 인증 없는 공지사항 삭제 테스트 API 추가

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeController.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -45,5 +46,11 @@ public class TestNoticeController implements TestNoticeControllerDocs {
       throws IOException {
     return ResponseEntity.ok(
         ApiResponse.onSuccess(noticeService.updateNotice(noticeId, req, newImages)));
+  }
+
+  @DeleteMapping("/{noticeId}")
+  public ResponseEntity<ApiResponse<Void>> deleteNotice(@PathVariable Long noticeId) {
+    noticeService.deleteNotice(noticeId);
+    return ResponseEntity.ok(ApiResponse.onSuccess(null));
   }
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/TestNoticeControllerDocs.java
@@ -55,4 +55,7 @@ public interface TestNoticeControllerDocs {
               encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)))
   ResponseEntity<ApiResponse<NoticeDetailResDto>> updateNotice(
       Long noticeId, NoticeUpdateReqDto req, List<MultipartFile> newImages) throws IOException;
+
+  @Operation(summary = "[TEST] 공지 삭제", description = "로그인 없이 공지사항을 삭제합니다. 테스트 API입니다.")
+  ResponseEntity<ApiResponse<Void>> deleteNotice(Long noticeId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #82

## 📝 작업 내용
- 인증 없이 공지사항을 삭제하는 테스트용 API 추가
- 기존 작성·수정 테스트 API(`POST`, `PUT /api/test/notices`)와 동일한 패턴으로 구현

## 📌 API 목록
- `DELETE /api/test/notices/{noticeId}` — 인증 없이 공지 삭제 (테스트용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 공지사항 삭제 기능 추가 (공지사항 ID를 통한 개별 삭제 지원)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->