### PR TITLE
Fix: 부스 랜덤ã 추천 운영예정도 포함, 운영여부 시간 테스트 코드 추가

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/controller/BoothControllerDocs.java
@@ -65,7 +65,8 @@ public interface BoothControllerDocs {
   @Operation(
       summary = "랜덤 부스 추천",
       description =
-          "festivalDay 기준 현재 '운영중' 상태인 부스 중 무작위 1개를 반환합니다." + " 운영중인 부스가 하나도 없으면 result가 null입니다.")
+          "festivalDay 기준 '운영중' 또는 '운영 예정' 상태인 부스 중 무작위 1개를 반환합니다."
+              + " 해당 상태의 부스가 하나도 없으면(모두 '운영 종료') result가 null입니다.")
   ResponseEntity<ApiResponse<BoothStatusItemResDto>> getRandomRecommendedBooth(
       @RequestParam @Min(1) int day);
 }

--- a/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
+++ b/src/main/java/com/ds/dsfest/domain/booth/service/BoothService.java
@@ -162,14 +162,16 @@ public class BoothService {
   }
 
   public BoothStatusItemResDto getRandomRecommendedBooth(int festivalDay) {
-    List<BoothStatusItemResDto> running = new ArrayList<>();
+    List<BoothStatusItemResDto> candidates = new ArrayList<>();
     for (BoothStatusItemResDto b : getBoothsWithStatus(festivalDay, false)) {
-      if (!b.tags().isEmpty() && TAG_RUNNING.equals(b.tags().get(0))) {
-        running.add(b);
+      if (b.tags().isEmpty()) continue;
+      String status = b.tags().get(0);
+      if (TAG_RUNNING.equals(status) || TAG_UPCOMING.equals(status)) {
+        candidates.add(b);
       }
     }
-    if (running.isEmpty()) return null;
-    return running.get(random.nextInt(running.size()));
+    if (candidates.isEmpty()) return null;
+    return candidates.get(random.nextInt(candidates.size()));
   }
 
   private LocalTime resolveEffectiveTime(int festivalDay, LocalDateTime now) {

--- a/src/main/java/com/ds/dsfest/global/config/ClockConfig.java
+++ b/src/main/java/com/ds/dsfest/global/config/ClockConfig.java
@@ -1,8 +1,12 @@
 package com.ds.dsfest.global.config;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,7 +16,25 @@ public class ClockConfig {
   private static final ZoneId FESTIVAL_ZONE = ZoneId.of("Asia/Seoul");
 
   @Bean
-  public Clock festivalClock() {
-    return Clock.system(FESTIVAL_ZONE);
+  public Clock festivalClock(@Value("${festival.fake-now:}") String fakeNow) {
+    if (fakeNow == null || fakeNow.isBlank()) {
+      return Clock.system(FESTIVAL_ZONE);
+    }
+    LocalDateTime fixed = parseFakeNow(fakeNow.trim());
+    return Clock.fixed(fixed.atZone(FESTIVAL_ZONE).toInstant(), FESTIVAL_ZONE);
+  }
+
+  private LocalDateTime parseFakeNow(String value) {
+    try {
+      return LocalDateTime.parse(value);
+    } catch (Exception ignored) {
+    }
+    try {
+      return LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    } catch (Exception ignored) {
+    }
+    return LocalDateTime.now(Clock.system(FESTIVAL_ZONE))
+        .toLocalDate()
+        .atTime(LocalTime.parse(value));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,4 @@ server:
 
 festival:
   start-date: ${FESTIVAL_START_DATE:2026-05-13}
+  fake-now: ${FESTIVAL_FAKE_NOW:}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 부스 랜덤 추천: 운영중만 -> 운영중, 운영예정
- 운영중 여부 시간 테스트용 코드 추가

### 스크린샷 (선택)

## 📌 API 목록

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
- fake-now: ${FESTIVAL_FAKE_NOW:} 이 상태면 디폴트 시스템 시계 사용(실제 시간)
- NOW: 12:00:00 -> 12시 기준으로 실행
