### PR TITLE
카운트다운 수정

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/artist/entity/CountdownStatus.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/entity/CountdownStatus.java
@@ -1,8 +1,8 @@
 package com.ds.dsfest.domain.artist.entity;
 
 public enum CountdownStatus {
-  MORE_THAN_24H,
-  WITHIN_24H,
+  MORE_THAN_72H,
+  WITHIN_72H,
   LIVE,
   ENDED
 }

--- a/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/ds/dsfest/domain/artist/service/ArtistService.java
@@ -90,10 +90,10 @@ public class ArtistService {
 
     Duration duration = Duration.between(now, start);
 
-    if (duration.compareTo(Duration.ofHours(24)) <= 0) {
-      return CountdownStatus.WITHIN_24H;
+    if (duration.compareTo(Duration.ofHours(72)) <= 0) {
+      return CountdownStatus.WITHIN_72H;
     }
 
-    return CountdownStatus.MORE_THAN_24H;
+    return CountdownStatus.MORE_THAN_72H;
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 이번 PR에서 구현/수정한 기능 요약
카운트다운 수정 (24시간에서 72시간)
### 스크린샷 (선택)

## 📌 API 목록

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 아티스트 공연 시작까지의 카운트다운 상태 기준이 24시간에서 72시간으로 변경되었습니다. 이제 공연 시작까지 72시간 이내일 때 "72시간 이내" 상태가 표시되며, 그 이상은 "72시간 초과" 상태로 구분됩니다. 공연 중(LIVE)과 종료(ENDED) 상태는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->