### PR TITLE
Fix: 상위 5개 공지 반환

### DIFF
--- a/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/controller/NoticeControllerDocs.java
@@ -41,6 +41,6 @@ public interface NoticeControllerDocs {
   ResponseEntity<ApiResponse<NoticeSearchResDto>> searchNotices(
       @RequestParam @NotBlank String keyword);
 
-  @Operation(summary = "자주 찾는 공지 조회", description = "조회수 상위 4개의 공지사항 목록을 반환합니다.")
+  @Operation(summary = "자주 찾는 공지 조회", description = "조회수 상위 5개의 공지사항 목록을 반환합니다.")
   ResponseEntity<ApiResponse<List<NoticeListItemResDto>>> getFrequentNotices();
 }

--- a/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/repository/NoticeRepository.java
@@ -23,7 +23,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
       "SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdAt DESC")
   List<Notice> searchByKeyword(@Param("keyword") String keyword);
 
-  List<Notice> findTop4ByOrderByViewCountDescCreatedAtDesc();
+  List<Notice> findTop5ByOrderByViewCountDescCreatedAtDesc();
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")

--- a/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/ds/dsfest/domain/notice/service/NoticeService.java
@@ -102,7 +102,7 @@ public class NoticeService {
 
     List<NoticeListItemResDto> recommended =
         results.isEmpty()
-            ? noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc().stream()
+            ? noticeRepository.findTop5ByOrderByViewCountDescCreatedAtDesc().stream()
                 .map(NoticeListItemResDto::from)
                 .toList()
             : List.of();
@@ -160,7 +160,7 @@ public class NoticeService {
 
   @Transactional(readOnly = true)
   public List<NoticeListItemResDto> getFrequentNoticeList() {
-    return noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc().stream()
+    return noticeRepository.findTop5ByOrderByViewCountDescCreatedAtDesc().stream()
         .map(NoticeListItemResDto::from)
         .toList();
   }

--- a/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/ds/dsfest/domain/notice/service/NoticeServiceTest.java
@@ -1,24 +1,5 @@
 package com.ds.dsfest.domain.notice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.ds.dsfest.domain.notice.constant.NoticeCategory;
 import com.ds.dsfest.domain.notice.dto.NoticeCreateReqDto;
 import com.ds.dsfest.domain.notice.dto.NoticeDetailResDto;
@@ -30,6 +11,22 @@ import com.ds.dsfest.domain.notice.exception.NoticeErrorCode;
 import com.ds.dsfest.domain.notice.repository.NoticeRepository;
 import com.ds.dsfest.global.exception.CustomException;
 import com.ds.dsfest.global.infra.s3.S3Uploader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class NoticeServiceTest {
@@ -158,7 +155,7 @@ class NoticeServiceTest {
   void searchNotices_empty_returnsRecommended() {
     Notice recommended = Notice.create("자주 찾는 공지", "내용", NoticeCategory.ETC, false);
     when(noticeRepository.searchByKeyword("없는키워드")).thenReturn(List.of());
-    when(noticeRepository.findTop4ByOrderByViewCountDescCreatedAtDesc())
+    when(noticeRepository.findTop5ByOrderByViewCountDescCreatedAtDesc())
         .thenReturn(List.of(recommended));
 
     NoticeSearchResDto result = noticeService.searchNotices("없는키워드");
@@ -178,7 +175,7 @@ class NoticeServiceTest {
 
     assertThat(result.results()).hasSize(1);
     assertThat(result.recommended()).isEmpty();
-    verify(noticeRepository, never()).findTop4ByOrderByViewCountDescCreatedAtDesc();
+    verify(noticeRepository, never()).findTop5ByOrderByViewCountDescCreatedAtDesc();
   }
 
   @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
-  close #93 
## 📝 작업 내용
- 자주 찾는 공지 상위 4개 -> 5개로 수정

### 스크린샷 (선택)

## 📌 API 목록
동일

## 💬 리뷰 요구사항 혹은 참고 사항 (선택)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 인기 공지사항 목록에 표시되는 공지사항의 개수가 4개에서 5개로 변경되었습니다.
  * 검색 결과에서 추천하는 공지사항도 4개에서 5개로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->